### PR TITLE
Add Provisioning Package feature

### DIFF
--- a/OSD.psd1
+++ b/OSD.psd1
@@ -162,6 +162,7 @@ FunctionsToExport =
 'Start-OOBE.settings',
 'Start-OOBE.wifi',
 'Edit-OSDCloud.winpe',#OSDCLOUD
+'Add-OSDCloudProvPackage',
 'Find-OSDCloudOfflineFile',
 'Find-OSDCloudOfflinePath',
 'Find-OSDCloudFile',
@@ -176,6 +177,7 @@ FunctionsToExport =
 'Save-OSDCloudOfflineModules',
 'Save-OSDCloud.usb',
 'Select-OSDCloudAutopilotFile',
+'Select-OSDCloudProvPackage',
 'Select-OSDCloudODTFile',
 'Set-OSDCloud.workspace',
 'Start-OSDCloud',

--- a/Public/OSDCloud/Add-OSDCloudProvPackage.ps1
+++ b/Public/OSDCloud/Add-OSDCloudProvPackage.ps1
@@ -1,0 +1,50 @@
+<#
+.SYNOPSIS
+Add Provisioning Packages to C:\ drive
+
+.DESCRIPTION
+Add Provisioning Packages to C:\ drive
+Assign temporary drive letter to volume if needed
+
+.PARAMETER All
+Selects all Provisioning Packages in PPKG folder
+#>
+function Add-OSDCloudProvPackage {
+    [CmdletBinding()]
+    param (
+        [Parameter(ValueFromPipeline)]
+        [object[]]$OSDCloudProvPackages
+    )
+    process {
+        foreach ($item in $OSDCloudProvPackages) {
+            $PPKGPath = $item.Fullname
+            $PPKGName = $item.name
+            $PPKGSourceDevice = $item.SourceDevice
+            
+            # Check if volume is accessible for dism ( does not support volume paths )
+            $SourceDriveLetter = Get-CimInstance Win32_Volume | Where-Object DeviceID -eq $PPKGSourceDevice | Select-Object -ExpandProperty Caption
+            if (!$SourceDriveLetter) {
+                # temporarily reassign drive letter if needed ( after Expand OS for example )
+                $tempAssign = $true
+                $freeDriveLetter = Get-ChildItem function:[d-z]: -Name | Where-Object{ !(test-path $_) } | Get-Random
+                $SourceDriveLetter = Set-Volume -UniqueId $PPKGSourceDevice -DriveLetter $freeDriveLetter
+            }
+            
+            $newPPKGPath = Join-Path $SourceDriveLetter (Split-Path -Path $PPKGPath -NoQualifier)
+            Write-Host -ForegroundColor DarkGray "Applying $PPKGName to Drive C: " -NoNewline
+        
+            $command = "DISM.exe /Image=c:\ /Add-ProvisioningPackage /PackagePath:`"$newPPKGPath`""
+            $result = $command | Invoke-Expression
+            if ($tempAssign) {
+                Get-Volume -UniqueId $PPKGSourceDevice | Get-Partition | Remove-PartitionAccessPath -AccessPath "$freeDriveLetter\"            
+            }
+            if ($LASTEXITCODE -eq 0) {
+                Write-Host -ForegroundColor Green "OK"
+            }
+            else {
+                Write-Host -ForegroundColor Red "FAIL"
+                throw "There was en error when applying $PPKGName offline. Error was $result"
+            }
+        }
+    }
+}

--- a/Public/OSDCloud/Edit-OSDCloud.winpe.ps1
+++ b/Public/OSDCloud/Edit-OSDCloud.winpe.ps1
@@ -105,6 +105,12 @@ function Edit-OSDCloud.winpe {
         robocopy "$WorkspacePath\Autopilot" "$MountPath\OSDCloud\Autopilot" *.* /mir /ndl /njh /njs /b /np
     }
     #=======================================================================
+    #   Add Provisioning Packages
+    #=======================================================================
+    if (Test-Path "$WorkspacePath\PPKG") {
+        robocopy "$WorkspacePath\PPKG" "$MountPath\OSDCloud\PPKG" *.* /mir /ndl /njh /njs /b /np
+    }
+    #=======================================================================
     #   Add ODT Config
     #=======================================================================
     if (Test-Path "$WorkspacePath\ODT") {

--- a/Public/OSDCloud/Invoke-OSDCloud.ps1
+++ b/Public/OSDCloud/Invoke-OSDCloud.ps1
@@ -47,9 +47,11 @@ function Invoke-OSDCloud {
         OSLicense = $null
         OSImageIndex = 1
         Product = Get-MyComputerProduct
+        ProvPackages = $null
         Screenshot = $null
         SkipAutopilot = [bool]$false
         SkipODT = [bool]$false
+        SkipProvPackage = [bool]$false
         Test = [bool]$false
         TimeEnd = $null
         TimeSpan = $null
@@ -178,6 +180,33 @@ function Invoke-OSDCloud {
         }
         else {
             Write-Warning "AutopilotConfigurationFile.json will not be configured for this deployment"
+        }
+    }
+    #=======================================================================
+    #	Provisioning Packages
+    #=======================================================================
+    if ($OSDCloud.SkipProvPackage -ne $true) {
+        Write-Host -ForegroundColor DarkGray "========================================================================="
+        Write-Host -ForegroundColor Cyan "$((Get-Date).ToString('yyyy-MM-dd-HHmmss')) Provisioning Packages Configuration"
+
+        if ($OSDCloud.ProvPackages) {
+            Write-Host -ForegroundColor DarkGray "Provisioning Packages already defined by variable"
+        }
+        else {
+            if ($OSDCloud.ZTI -eq $true) {
+                Write-Host -ForegroundColor DarkGray "Skip Provisioning Packages selection in ZTI"
+            }
+            else {
+                $OSDCloud.ProvPackages = Select-OSDCloudProvPackage
+            }
+        }
+
+        if ($OSDCloud.ProvPackages) {
+            Write-Host -ForegroundColor Cyan "OSDCloud will apply the following Provisioning Packages"
+            $OSDCloud.ProvPackages | Select-Object Name,Fullname | Format-Table
+        }
+        else {
+            Write-Warning "Provisioning Packages will not be configured for this deployment"
         }
     }
     #=======================================================================

--- a/Public/OSDCloud/New-OSDCloud.template.ps1
+++ b/Public/OSDCloud/New-OSDCloud.template.ps1
@@ -670,6 +670,11 @@ Windows Registry Editor Version 5.00
         New-Item -Path $SourcePath -ItemType Directory -Force | Out-Null
     }
 
+    $SourcePath = "$TemplatePath\PPKG"
+    if (-NOT (Test-Path $SourcePath)) {
+        New-Item -Path $SourcePath -ItemType Directory -Force | Out-Null
+    }
+
     $SourcePath = "$TemplatePath\DriverPacks\Dell"
     if (-NOT (Test-Path $SourcePath)) {
         Write-Host -ForegroundColor DarkGray $SourcePath

--- a/Public/OSDCloud/Select-OSDCloudProvPackage.ps1
+++ b/Public/OSDCloud/Select-OSDCloudProvPackage.ps1
@@ -1,0 +1,67 @@
+<#
+.SYNOPSIS
+Selects Provisioning Packages
+
+.DESCRIPTION
+Selects Provisioning Packages
+
+.PARAMETER All
+Selects all Provisioning Packages in PPKG folder
+
+.NOTES
+General notes
+#>
+function Select-OSDCloudProvPackage {
+    [CmdletBinding()]
+    param (
+        [switch]$All
+    )
+    $i = $null
+    $FindOSDCloudFile = Find-OSDCloudFile -Name "*.ppkg" -Path '\OSDCloud\PPKG\' | Sort-Object FullName
+    $FindOSDCloudFile = $FindOSDCloudFile | Where-Object { $_.FullName -notlike "C*" }
+
+    if ($FindOSDCloudFile) {
+        $ProvisioningPackages = foreach ($Item in $FindOSDCloudFile) {
+            $i++
+            
+            $root = $Item.PSDrive.Root
+            $SourceDevice = Get-CimInstance win32_Volume -Filter "Caption='$root\'" | Select-Object -ExpandProperty DeviceID # Get-Volume does not return device id for ramdrives
+            #$Fullpath = Join-Path -Path $DeviceID (Split-Path $Item -NoQualifier)
+    
+            [PSCustomObject]@{
+                Selection    = $i
+                Name         = $Item.Name
+                Fullname     = $Item.Fullname
+                SourceDevice = $SourceDevice
+            }            
+        }
+
+        if (!$All) {
+            $ProvisioningPackages | Select-Object -Property Selection, Name, Fullname | Format-Table | Out-Host
+            $SelectedItems = @()                    
+            do {
+                if ($SelectedItems) { Write-Host "Current selection : $($SelectedItems -join ",") " }
+            
+                $SelectReadHost = Read-Host -Prompt "Enter the Selection of the Provisioning Package to apply, press [A]ll or [D]one or [S]kip"
+                if ($SelectReadHost -in $ProvisioningPackages.Selection -and $SelectReadHost -notin $SelectedItems) {
+                    $SelectedItems += $SelectReadHost
+                }
+                elseif ($SelectReadHost -eq 'A') {
+                    $SelectedItems = $ProvisioningPackages.Selection
+                }
+            }
+            until (($SelectedItems.count -eq $ProvisioningPackages.count) -or
+                $SelectReadHost -eq 'S' -or
+                $SelectReadHost -eq 'D'
+            )
+        
+            if ($SelectReadHost -eq 'S') {
+                return $false
+            }
+
+            $ProvisioningPackages = $ProvisioningPackages | Where-Object { $_.Selection -in $SelectedItems }
+        }
+    
+        Return $ProvisioningPackages
+    }
+}

--- a/Public/OSDCloud/Start-OSDCloud.ps1
+++ b/Public/OSDCloud/Start-OSDCloud.ps1
@@ -31,6 +31,8 @@ function Start-OSDCloud {
 
         [switch]$SkipAutopilot,
 
+        [switch]$SkipProvPackage,
+
         [switch]$SkipODT,
 
         [switch]$ZTI,
@@ -104,6 +106,7 @@ function Start-OSDCloud {
         Product = $Product
         Screenshot = $null
         SkipAutopilot = $SkipAutopilot
+        SkipProvPackage = $SkipProvPackage
         SkipODT = $SkipODT
         TimeStart = Get-Date
         ZTI = $ZTI


### PR DESCRIPTION
Added two functions to support Provisioning Packages in a similar way as Autopilot Profiles. 
Added some logic to support multiselection of Provisioning Packages.
Usage:
Simply put your *.ppkg files into your PPKG folder. 

Example Szenarios:
- prestaging Wifi-Profiles before OOBE  (will skip Autopilot WiFi selection page)
- blocking Shift + F10 in OOBE
- Kiosk provisioning

Let me know if  there are any problems