### PR TITLE
added support for unattended connection to WIFI network

### DIFF
--- a/OSD.psd1
+++ b/OSD.psd1
@@ -237,6 +237,7 @@ FunctionsToExport =
 'Get-PartitionWinRE',
 'Copy-WinRE.wim',
 'Connect-WinREWiFi',
+'Connect-WinREWiFiByXMLProfile',
 'Get-WinREWiFi',
 'Set-WinREWiFi',
 'Start-WinREWiFi',


### PR DESCRIPTION
Added function Connect-WinREWiFiByXMLProfile for unattended connection to Wi-Fi using exported XML profile (result of command similar to this: netsh wlan export profile name=`"MyWifiSSID`" key=clear folder=C:\Wifi)

Modified function Start-WinREWiFi to support this new option.