### PR TITLE
Adding Gitlab API Support

### DIFF
--- a/Projects/OSDPad.ps1
+++ b/Projects/OSDPad.ps1
@@ -84,7 +84,14 @@ if ($Global:OSDPad) {
             $ScriptSelectionControl.SelectedValue = $_.Path
         }
         if ($Global:OSDPadBranding.Title -eq 'OSDPad') {
-            $Global:OSDPadBranding.Title = "github.com/$RepoOwner/$RepoName/"
+            switch ($RepoType) {
+                'GitHub' {
+                    $Global:OSDPadBranding.Title = "github.com/$RepoOwner/$RepoName/"
+                }
+                'GitLab' {
+                    $Global:OSDPadBranding.Title = "$RepoDomain/$RepoName/"
+                }
+            }
         }
     }
 }

--- a/Public/Functions/split/Start-OSDPad.ps1
+++ b/Public/Functions/split/Start-OSDPad.ps1
@@ -6,14 +6,21 @@ function Start-OSDPad {
         [string]$RepoOwner,
         
         [Parameter(ParameterSetName = 'GitHub', Mandatory = $true, Position = 1)]
+        [Parameter(ParameterSetName = 'GitLab', Mandatory = $true, Position = 0)]        
         [Alias('Repository','GitRepo')]
         [string]$RepoName,
         
         [Parameter(ParameterSetName = 'GitHub', Position = 2)]
+        [Parameter(ParameterSetName = 'GitLab', Position = 1)]
         [Alias('GitPath','Folder')]
         [string]$RepoFolder,
         
+        [Parameter(ParameterSetName = 'GitLab', Mandatory = $true)]
+        [Alias('GitLabUri')]
+        [string]$RepoDomain,
+
         [Parameter(ParameterSetName = 'GitHub')]
+        [Parameter(ParameterSetName = 'GitLab')]
         [Alias('OAuthToken')]
         [string]$OAuth,
 
@@ -37,6 +44,7 @@ function Start-OSDPad {
     #   GitHub
     #================================================
     if ($PSCmdlet.ParameterSetName -eq 'GitHub') {
+        $RepoType = "GitHub"
         $Uri = "https://api.github.com/repos/$RepoOwner/$RepoName/contents/$RepoFolder"
         Write-Host -ForegroundColor DarkCyan $Uri
 
@@ -118,6 +126,7 @@ function Start-OSDPad {
                 }
         
                 $ObjectProperties = @{
+                    RepoType        = $RepoType
                     RepoOwner       = $RepoOwner
                     RepoName        = $RepoName
                     RepoFolder      = $RepoFolder
@@ -139,6 +148,108 @@ function Start-OSDPad {
         }
         $Global:OSDPad = $Results
         
+    }
+    #================================================
+    #   GitLab
+    #================================================
+    elseif ($PSCmdlet.ParameterSetName -eq 'GitLab') {        
+        $RepoType = "GitLab"
+        $RestAPI = "api/v4/projects/$RepoName/repository/tree?path=$RepoFolder&recursive=true"
+        $Uri = "https://$RepoDomain/$RestAPI"       
+        Write-Host -ForegroundColor DarkCyan $Uri
+        
+        $Params = @{
+            Method          = 'GET'
+            Uri             = $Uri
+            UseBasicParsing = $true
+        }
+        IF ($OAuth) { 
+            $Params.add("Headers", @{"PRIVATE-TOKEN" = "$OAuth" }) 
+        }  
+        
+        $GitLabApiContent = @()
+        try {
+            $GitLabApiContent = Invoke-RestMethod @Params -ErrorAction Stop
+        }
+        catch {
+            Write-Warning $_
+            Break
+        }      
+
+        $GitLabApiContent = $GitLabApiContent | Where-Object { ($_.name -like "*.md") -or ($_.name -like "*.ps1") }
+        
+        Write-Host -ForegroundColor DarkGray "========================================================================="
+        $Results = foreach ($Item in $GitLabApiContent) {
+            #$FileContent = Invoke-RestMethod -UseBasicParsing -Uri $Item.git_url
+            if ($Item.type -eq 'tree') {
+                Write-Host -ForegroundColor DarkCyan "Directory: Start-OSDPad $RepoDomain $RepoName $($Item.name)"
+                
+                $ObjectProperties = @{
+                    RepoOwner  = $RepoOwner
+                    RepoName   = $RepoName
+                    RepoFolder = $RepoFolder
+                    Name       = $Item.name
+                    Type       = $Item.type
+                    Guid       = New-Guid
+                    Path       = $Item.path
+                    Size       = $Item.size
+                    SHA        = $Item.sha
+                    Git        = $Item.git_url
+                    Download   = $Item.download_url
+                    ContentRAW = $null
+                    #NodeId         = $FileContent.node_id
+                    #Content        = $FileContent.content
+                    #Encoding       = $FileContent.encoding
+                }
+                #New-Object -TypeName PSObject -Property $ObjectProperties
+            }
+            else {
+                $filePath = [System.Web.HttpUtility]::UrlEncode($Item.path)
+                $RestAPI = "api/v4/projects/$RepoName/repository/files/$filePath/raw?ref=main"
+                $Uri = "https://$RepoDomain/$RestAPI"
+                Write-Host -ForegroundColor DarkGray $Uri
+                
+                $Params = @{
+                    Method          = 'GET'
+                    Uri             = $Uri
+                    UseBasicParsing = $true
+                }
+                IF ($OAuth) { 
+                    $Params.add("Headers", @{"PRIVATE-TOKEN" = "$OAuth" }) 
+                }                
+
+                try {
+                    $ScriptWebRequest = Invoke-RestMethod @Params -ErrorAction Ignore
+                }
+                catch {
+                    Write-Warning $_
+                    $ScriptWebRequest = $null
+                    Continue
+                }
+        
+                $ObjectProperties = @{
+                    RepoType   = $RepoType
+                    RepoDomain = $RepoDomain
+                    #RepoOwner  = $RepoOwner
+                    RepoName   = $RepoName
+                    RepoFolder = $RepoFolder
+                    Name       = $Item.name
+                    Type       = $Item.type
+                    Guid       = $Item.id
+                    Path       = $Item.path
+                    #Size       = $Item.size
+                    #SHA        = $Item.sha
+                    #Git        = $Item.git_url
+                    #Download   = $Item.download_url
+                    ContentRAW = $ScriptWebRequest
+                    #NodeId         = $FileContent.node_id
+                    #Content        = $FileContent.content
+                    #Encoding       = $FileContent.encoding
+                }
+                New-Object -TypeName PSObject -Property $ObjectProperties
+            }
+        }
+        $Global:OSDPad = $Results
     }
     else {
         $Global:OSDPad = $null


### PR DESCRIPTION
Adding Gitlab API Support

This change adds support for accessing GitLab repositories with or without OAuth.  This update does not alter the existing switches so that existing configurations will not need to be modified. 

Existing switches that have verified and worked
```
Start-OSDPad OSDeploy OSDHelp OSDCloudDeploy [-OAuth xxxxxxxxxxx]
Start-OSDPad -RepoOwner OSDeploy -RepoName OSDHelp -RepoFolder OSDCloudDeploy [-OAuth xxxxxxxxxxx]
```

Screen Capture
![github example](https://user-images.githubusercontent.com/56890437/174912471-47fc5957-a949-46f9-b761-5b7d2a32fdc0.png)

New switches to support GitLab 
```
Start-OSDPad 26 Scripts -RepoDomain gitlab.domain.com [-OAuth xxxxxxxxxxx]
Start-OSDPad -RepoName 26 -RepoFolder Scripts -RepoDomain gitlab.domain.com [-OAuth xxxxxxxxxxx]
```

Screen Capture
![gitlab example](https://user-images.githubusercontent.com/56890437/174912518-8a12599d-2805-4c4a-865f-4879e6e99caa.png)


