### PR TITLE
Adding support for Dell Update Packages

### DIFF
--- a/Public/OSDCloud.ps1
+++ b/Public/OSDCloud.ps1
@@ -1151,7 +1151,7 @@ function Invoke-OSDCloud {
                 #=================================================
                 #   Dell Update Package
                 #=================================================
-                if ($Item.Extension -eq '.exe' -and $Item.FullName -like '*_A*') {
+                if ($Item.Extension -eq '.exe' -and $Global:OSDCloud.Manufacturer -eq 'Dell') {
                     $DestinationPath = Join-Path $Item.Directory $Item.BaseName
                     if (-NOT (Test-Path "$DestinationPath")) {
                         Write-DarkGrayHost "Dell Update Package is being expanded to $DestinationPath"

--- a/Public/OSDCloud.ps1
+++ b/Public/OSDCloud.ps1
@@ -1149,6 +1149,17 @@ function Invoke-OSDCloud {
                     Continue
                 }
                 #=================================================
+                #   Dell Update Package
+                #=================================================
+                if ($Item.Extension -eq '.exe' -and $Item.FullName -like '*_A*') {
+                    $DestinationPath = Join-Path $Item.Directory $Item.BaseName
+                    if (-NOT (Test-Path "$DestinationPath")) {
+                        Write-DarkGrayHost "Dell Update Package is being expanded to $DestinationPath"
+                        Start-Process -FilePath $ExpandFile -ArgumentList "/s /e=$DestinationPath" -Wait
+                    }
+                    Continue
+                }
+                #=================================================
             }
         }
 


### PR DESCRIPTION
Adding support for Dell Update Packages

Dell provides their driver packages for newer models in a so called "Dell Update Package" / "DUP".
This change adds the capability to expand these DUPs.

Please find more information on the Dell website:
https://www.dell.com/support/kbdoc/en-us/000197955/file-format-change-of-dell-command-deploy-driver-pack-from-cab-to-dup