### PR TITLE
Update New-Bootable.usb.ps1

### DIFF
--- a/Public/Functions/split/New-Bootable.usb.ps1
+++ b/Public/Functions/split/New-Bootable.usb.ps1
@@ -80,6 +80,11 @@ function New-Bootable.usb {
         Write-Verbose '$GetUSBDisk | Initialize-Disk -PartitionStyle MBR'
         $GetUSBDisk | Initialize-Disk -PartitionStyle MBR -ErrorAction Stop
     }
+    
+    if ($GetUSBDisk.PartitionStyle -eq 'GPT') {
+        Write-Verbose '$GetUSBDisk | Set-Disk -PartitionStyle MBR'
+        $GetUSBDisk | Set-Disk -PartitionStyle MBR -ErrorAction Stop
+    }
 
     if ($GetUSBDisk.SizeGB -le 2000) {
         Write-Verbose '$DataDisk = $GetUSBDisk | New-Partition -Size ($GetUSBDisk.Size - 2GB) -AssignDriveLetter | Format-Volume -FileSystem NTFS -NewFileSystemLabel $DataLabel'


### PR DESCRIPTION
Fix for https://github.com/OSDeploy/OSD/issues/42

I tried `Initialize-Disk`, but it threw error "Initialize-Disk : The disk has already been initialized.", so went with `Set-Disk` instead.