### PR TITLE
Bugfixed Save-WebFile and Update-MyWindowsImage

### DIFF
--- a/Public/Functions/split/Save-WebFile.ps1
+++ b/Public/Functions/split/Save-WebFile.ps1
@@ -109,9 +109,9 @@ function Save-WebFile {
 
         if ($UseWebClient -eq $true) {
             [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls1
-            $WebClient = New-Object System.Net.WebClient
-            $WebClient.DownloadFile($SourceUrl, $DestinationFullName)
-            $WebClient.Dispose()
+            $WebClientTemp = New-Object System.Net.WebClient
+            $WebClientTemp.DownloadFile($SourceUrl, $DestinationFullName)
+            $WebClientTemp.Dispose()
         }
         else {
             Write-Verbose "cURL Source: $SourceUrl"

--- a/Public/Functions/split/Update-MyWindowsImage.ps1
+++ b/Public/Functions/split/Update-MyWindowsImage.ps1
@@ -92,10 +92,10 @@ function Update-MyWindowsImage {
             $global:GetWSUSXML = Get-WSUSXML -Catalog Windows -Silent | Sort-Object UpdateGroup -Descending
 
             if ($global:GetRegCurrentVersion.ReleaseId -gt 0) {
-                $global:GetWSUSXML = $global:GetWSUSXML | Where-Object {$_.UpdateBuild -eq $global:GetRegCurrentVersion.DisplayVersion}
+                $global:GetWSUSXML = $global:GetWSUSXML | Where-Object {$_.UpdateBuild -eq $global:GetRegCurrentVersion.ReleaseId}
             }
             else {
-                $global:GetWSUSXML = $global:GetWSUSXML | Where-Object {$_.UpdateBuild -eq $global:GetRegCurrentVersion.ReleaseId}
+                $global:GetWSUSXML = $global:GetWSUSXML | Where-Object {$_.UpdateBuild -eq $global:GetRegCurrentVersion.DisplayVersion}
             }
 
             if ($global:GetRegCurrentVersion.BuildLabEx -match 'amd64') {


### PR DESCRIPTION
Hi David,

I wanted to test the integration of OSD in my build processes today instead of using OSDBuilder which we talked about on Twitter this week. While testing I found some issues when not having curl.exe at hand and updating WS2016 OS.

Save-WebFile: I renamed $WebClient to $WebClientTemp when it comes to the download itself as it interferes with the Param $WebClient which is of another type (System.Management.Automation.SwitchParameter instead of System.Net.WebClient) which can't be changed at this stage. As a consequence the download fails.

Update-MyWindows Image: I never got any updates reported, even on very old install.wim files. I guess that the fact that Get-RegCurrentVersion running on WS2016 does not return ReleaseId is the issue here. Did you accidently swapped DisplayVersion and ReleaseId? Swapping these fields in the If-statement fixes the issue with 2016.

Please let me know if I can do better providing Pull-Requests. As always you can also reach out to me via Twitter (@andre_sicking).