### PR TITLE
Minor bug fixing

### DIFF
--- a/Public/Functions/split/Save-WebFile.ps1
+++ b/Public/Functions/split/Save-WebFile.ps1
@@ -109,9 +109,9 @@ function Save-WebFile {
 
         if ($UseWebClient -eq $true) {
             [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls1
-            $WebClient = New-Object System.Net.WebClient
-            $WebClient.DownloadFile($SourceUrl, $DestinationFullName)
-            $WebClient.Dispose()
+            $WebClientTemp = New-Object System.Net.WebClient
+            $WebClientTemp.DownloadFile($SourceUrl, $DestinationFullName)
+            $WebClientTemp.Dispose()
         }
         else {
             Write-Verbose "cURL Source: $SourceUrl"

--- a/Public/Functions/split/Update-MyWindowsImage.ps1
+++ b/Public/Functions/split/Update-MyWindowsImage.ps1
@@ -91,7 +91,7 @@ function Update-MyWindowsImage {
             #=================================================
             $global:GetWSUSXML = Get-WSUSXML -Catalog Windows -Silent | Sort-Object UpdateGroup -Descending
 
-            if ($global:GetRegCurrentVersion.ReleaseId -gt 0) {
+            if ($global:GetRegCurrentVersion.DisplayVersion -gt 0) {
                 $global:GetWSUSXML = $global:GetWSUSXML | Where-Object {$_.UpdateBuild -eq $global:GetRegCurrentVersion.DisplayVersion}
             }
             else {


### PR DESCRIPTION
When 'curl.exe' is not available, $WebClient cannot be assigned a new object [System.Net.WebClient] as it is already defined as [System.Management.Automation.SwitchParameter] in the param section. So for downloading updates successfully without 'curl.exe' I just renamed the variable to make sure the object can be created.

The If-Statement in Update-MyWindowsImage delivers the wrong registry field when reporting the found version.