### PR TITLE
Fixed Get-DellWinPEDriverPack

### DIFF
--- a/Public/Functions/DriverPack/Get-DellWinPEDriverPack.ps1
+++ b/Public/Functions/DriverPack/Get-DellWinPEDriverPack.ps1
@@ -33,7 +33,7 @@ function Get-DellWinPEDriverPack {
         try {
             $null = Invoke-WebRequest -Uri $CurrentDriverPackPage -Method Head -UseBasicParsing -ErrorAction Stop
             Write-Verbose "Online: $CurrentDriverPackPage"
-            $CurrentDriverPack = (Invoke-WebRequest -Uri $CurrentDriverPackPage -UseBasicParsing -Method Get).Links | Where-Object {$_.outerHTML -match 'Download Now'} | Select-Object -ExpandProperty href
+            $CurrentDriverPack = (Invoke-WebRequest -Uri $CurrentDriverPackPage -UseBasicParsing -Method Get).Links | Where-Object {$_.href -like 'https://*.dell.com/*/WinPE10*.CAB'} | Select-Object -ExpandProperty href
             $CurrentDriverPack = $CurrentDriverPack.Replace('dl.dell.com', 'downloads.dell.com')
         }
         catch {


### PR DESCRIPTION
In my case the requests to the Dell website are automatically forwarded to a German version of the page.
The download button is not called "Download Now" in the German version. It is called "Jetzt herunterladen".
I changed the filter a bit, so that it is more robust.