### PR TITLE
Add TPM manufacturer and version strings to main cmd window

### DIFF
--- a/Public/OSDCloudTS/Initialize-OSDCloudStartnetUpdate.ps1
+++ b/Public/OSDCloudTS/Initialize-OSDCloudStartnetUpdate.ps1
@@ -131,7 +131,7 @@ function Initialize-OSDCloudStartnetUpdate {
                 Start-Sleep -Seconds 5
             }
             else {
-                Write-Host -ForegroundColor Green "TPM 2.0 and Autopilot: Supported"
+                Write-Host -ForegroundColor Green "TPM 2.0 ($($Win32Tpm.ManufacturerIdTxt), $($Win32Tpm.ManufacturerVersion)) and Autopilot: Supported"
                 #Write-Host -ForegroundColor DarkGray "TPM IsActivated: $($Win32Tpm.IsActivated_InitialValue)"
                 #Write-Host -ForegroundColor DarkGray "TPM IsEnabled: $($Win32Tpm.IsEnabled_InitialValue)"
                 #Write-Host -ForegroundColor DarkGray "TPM IsOwned: $($Win32Tpm.IsOwned_InitialValue)"


### PR DESCRIPTION
Idea pitched to David a while back.
Doesn't add any extra lines to the output, just extra characters.

![image](https://github.com/OSDeploy/OSD/assets/1776037/80e99577-1d09-435b-a9d9-256a556ab2e8)
