### PR TITLE
Update Invoke-HPIA.ps1 - Write-CMTraceLog Fix

### DIFF
--- a/Public/OSDCloudTS/Invoke-HPIA.ps1
+++ b/Public/OSDCloudTS/Invoke-HPIA.ps1
@@ -229,12 +229,12 @@ Function Invoke-HPIA {
     try {
 
         if ($ReferenceFile){
-            CMTraceLog -LogFile $CMTraceLog -Message "/Operation:$Operation /Category:$Category /Selection:$Selection /Action:$Action $Silent $Noninteractive /Debug /ReportFolder:$ReportsFolder /ReferenceFile:$ReferenceFile" -Component $LogComp
+            Write-CMTraceLog -LogFile $CMTraceLog -Message "/Operation:$Operation /Category:$Category /Selection:$Selection /Action:$Action $Silent $Noninteractive /Debug /ReportFolder:$ReportsFolder /ReferenceFile:$ReferenceFile" -Component $LogComp
             Write-Host "Running HPIA With Args: /Operation:$Operation /Category:$Category /Selection:$Selection /Action:$Action $Silent $Noninteractive /Debug /ReportFolder:$ReportsFolder /ReferenceFile:$ReferenceFile" -ForegroundColor Green
             $Process = Start-Process -FilePath $HPIAInstallPath\HPImageAssistant.exe -WorkingDirectory $TempWorkFolder -ArgumentList "/Operation:$Operation /Category:$Category /Selection:$Selection /Action:$Action $Silent $Noninteractive /Debug /ReportFolder:$ReportsFolder /ReferenceFile:$ReferenceFile" -NoNewWindow -PassThru -Wait -ErrorAction Stop
         }
         else {
-            CMTraceLog -LogFile $CMTraceLog -Message "/Operation:$Operation /Category:$Category /Selection:$Selection /Action:$Action $Silent $Noninteractive /Debug /ReportFolder:$ReportsFolder" -Component $LogComp
+            Write-CMTraceLog -LogFile $CMTraceLog -Message "/Operation:$Operation /Category:$Category /Selection:$Selection /Action:$Action $Silent $Noninteractive /Debug /ReportFolder:$ReportsFolder" -Component $LogComp
             Write-Host "Running HPIA With Args: /Operation:$Operation /Category:$Category /Selection:$Selection /Action:$Action $Silent $Noninteractive /Debug /ReportFolder:$ReportsFolder" -ForegroundColor Green
             $Process = Start-Process -FilePath $HPIAInstallPath\HPImageAssistant.exe -WorkingDirectory $TempWorkFolder -ArgumentList "/Operation:$Operation /Category:$Category /Selection:$Selection /Action:$Action $Silent $Noninteractive /Debug /ReportFolder:$ReportsFolder" -NoNewWindow -PassThru -Wait -ErrorAction Stop
         }


### PR DESCRIPTION
When running the SetupComplete phase, the 'Invoke-HPIA' is not running HPIA as the logging function is not being called properly. This results in the try failing over to the catch and HPIA never ends up running.

1. Manually running 'Invoke-HPIA' from the OSD module
2. Importing this Pull request of Invoke-HPIA.ps1
3. Running again and getting a successful run

![image](https://github.com/OSDeploy/OSD/assets/126358188/fd28b99d-723a-45fd-b2bb-0d8e47e1e51c)

