### PR TITLE
Added start-sleep of 10 secondes

### DIFF
--- a/Public/OSDCloudTS/Start-WindowsUpdateDrivers.ps1
+++ b/Public/OSDCloudTS/Start-WindowsUpdateDrivers.ps1
@@ -102,7 +102,7 @@ Function Start-WindowsUpdateDriver{
         Remove-Job -Force $Installing
 
         #Start-sleep
-        Start-sleep 10
+        Start-sleep -seconds 10
         
     }
 }

--- a/Public/OSDCloudTS/Start-WindowsUpdateDrivers.ps1
+++ b/Public/OSDCloudTS/Start-WindowsUpdateDrivers.ps1
@@ -100,5 +100,9 @@ Function Start-WindowsUpdateDriver{
 
         # Clean up the job
         Remove-Job -Force $Installing
+
+        #Start-sleep
+        Start-sleep 10
+        
     }
 }


### PR DESCRIPTION
Hi,

We encountered an issue where several HP devices lost internet connectivity after driver updates were applied. In the next step by installing updates from HPCMSL, but since there was no internet access, HPCMSL couldn't be downloaded. Adding a brief `Start-Sleep` command will help resolve this problem.