### PR TITLE
Replace WebClient in Invoke-WebPSScript and add Headers functionality

### DIFF
--- a/Public/Functions/Other/Test-WebConnection.ps1
+++ b/Public/Functions/Other/Test-WebConnection.ps1
@@ -3,6 +3,10 @@
 Tests to see if a Uri by Invoke-WebRequest -Method Head
 .DESCRIPTION
 Tests to see if a Uri by Invoke-WebRequest -Method Head
+.PARAMETER Uri
+Uri to test
+.PARAMETER Headers
+Additional headers to pass through
 .LINK
 https://github.com/OSDeploy/OSD/tree/master/Docs
 #>
@@ -12,15 +16,25 @@ function Test-WebConnection
     param
     (
         [Parameter(ValueFromPipeline)]
-        # Uri to test
         [System.Uri]
-        $Uri = 'google.com'
+        $Uri = 'google.com',
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.Collections.IDictionary]
+        $Headers
     )
     $Params = @{
         Method = 'Head'
         Uri = $Uri
         UseBasicParsing = $true
         Headers = @{'Cache-Control'='no-cache'}
+    }
+
+    if ($null -ne $Headers) {
+        foreach ($Header in $Headers.GetEnumerator()) {
+            $Params.Headers.Add($Header.Key,$Header.Value)
+        }
     }
 
     try {

--- a/Public/Functions/WebPSScript/Invoke-WebPSScript.ps1
+++ b/Public/Functions/WebPSScript/Invoke-WebPSScript.ps1
@@ -3,6 +3,10 @@
 Allows you to execute a PowerShell Script as a URL Link
 .DESCRIPTION
 Allows you to execute a PowerShell Script as a URL Link
+.PARAMETER Uri
+The URL of the PowerShell Script to execute.  Redirects are not allowed
+.PARAMETER Headers
+Additional headers to be sent in the request, for example authorization headers.
 .LINK
 https://github.com/OSDeploy/OSD/tree/master/Docs
 #>
@@ -14,21 +18,54 @@ function Invoke-WebPSScript
         [Parameter(Mandatory, ValueFromPipeline)]
         [Alias('WebPSScript')]
         [System.Uri]
-        # The URL of the PowerShell Script to execute.  Redirects are not allowed
-        $Uri
+        $Uri,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.Collections.IDictionary]
+        $Headers
     )
 
     $Uri = $Uri -replace '%20',' '
     Write-Verbose $Uri -Verbose
     
-    if (-NOT (Test-WebConnection $Uri))
+    # Pass Headers through to Test-WebConnection to properly test the connection
+    $Params = @{
+        Uri = $Uri
+    }
+
+    if ($null -ne $Headers)
+    {
+        $Params.Add('Headers', $Headers)
+    }
+
+    if (-NOT (Test-WebConnection @Params))
     {
         Return
     }
-    #[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
     [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls1
-    $WebClient = New-Object System.Net.WebClient
-    $WebPSCommand = $WebClient.DownloadString("$Uri")
+
+    # Disable progress bar while Invoke-WebRequest is running for a small performance gain
+    $PreviousProgressPreference = $ProgressPreference
+    $ProgressPreference = 'SilentlyContinue'
+
+    $Params = @{
+        Uri             = $Uri
+        Method          = 'GET'
+        ContentType     = "text/plain"
+        UseBasicParsing = $true
+    }
+
+    if ($null -ne $Headers) {
+        Write-Verbose -Message "Invoke-WebPSScript: Added Headers: $($Headers.Keys -join ', ')"
+        $Params.Add('Headers', $Headers)
+    }
+
+    $WebPSCommand = (Invoke-WebRequest @Params).Content
+
+    # Reset progress bar to whatever it was before
+    $ProgressPreference = $PreviousProgressPreference
+
     Invoke-Expression -Command $WebPSCommand
-    $WebClient.Dispose()
 }


### PR DESCRIPTION
First pull request on GitHub, hope this is fine! :)
I've been using OSD for over a year now and wanted to contribute to the project.

My two commits do three things:
- **Replace the deprecated WebClient in Invoke-WebPSScript with Invoke-WebRequest**<br>The usage of WebClient seems very different to how other Cmdlets handle things, also it's very much deprecated. This will simply replace it with Invoke-WebRequest, but does not add any specific error handling.
- **Add Headers parameter to Invoke-WebPSScript**<br>This allows the user to pass-through headers to the web request made by Invoke-WebPSScript. This is very helpful when - for example - accessing scripts on private Git Repositories via PATs or other file storages that utilize Authorization tokens.
- **Add Headers parameter to Test-WebConnection**<br>In testing I noticed that GitHub reports 404 on private repos when the token is not provided. This allows the Connection check to pass in that case, by also passing the headers through to it from Invoke-WebPSScript.

Since any problem or bug with Invoke-WebPSScript will probably break a lot of people's deployments, the switch to Invoke-WebRequest would need to be tested more thoroughly than I can before being pushed out, but it didn't seem to break anything in my testing.

I did not make any changes to the help/docs, since I'm guessing those are just auto-generated. Just hoping I'm right with that.

If you notice any problems/bugs, I'll try to fix them when I get around to it.
