### PR TITLE
Handle null value for $PackageID

### DIFF
--- a/Public/OSDCloudTS/Test-DISMFromOSDCloudUSB.ps1
+++ b/Public/OSDCloudTS/Test-DISMFromOSDCloudUSB.ps1
@@ -21,8 +21,12 @@
     if ($OSDCloudDriveLetter){
         $ComputerProduct = (Get-MyComputerProduct)
         if (!($PackageID)){
-            $PackageID = $DriverPack.PackageID
             $DriverPack = Get-OSDCloudDriverPack -Product $ComputerProduct
+            $PackageID = $DriverPack.PackageID
+        }
+        #Secondary $null check
+        if (!($PackageID)){
+            $PackageID = "dummy_path"
         }
         $ComputerManufacturer = (Get-MyComputerManufacturer -Brief)
         if ($ComputerManufacturer -match "Samsung"){$ComputerManufacturer = "Samsung"}


### PR DESCRIPTION
Fixed order of processing variables and added a second null check to compensate for null variables.