### PR TITLE
Handle null value for $PackageID and add ComputerModel to Test-Path

### DIFF
--- a/Public/OSDCloudTS/Start-DISMFromOSDCloudUSB.ps1
+++ b/Public/OSDCloudTS/Start-DISMFromOSDCloudUSB.ps1
@@ -21,6 +21,7 @@
         }
         if ($OSDCloudDriveLetter){
             $ComputerProduct = (Get-MyComputerProduct)
+            $ComputerModel = (Get-MyComputerModel)
             if (!($PackageID)){
                 $DriverPack = Get-OSDCloudDriverPack -Product $ComputerProduct
                 if ($DriverPack){
@@ -30,6 +31,7 @@
             $ComputerManufacturer = (Get-MyComputerManufacturer -Brief)
             if ($ComputerManufacturer -match "Samsung"){$ComputerManufacturer = "Samsung"}
             $DriverPathProduct = "$($OSDCloudDriveLetter):\OSDCloud\DriverPacks\DISM\$ComputerManufacturer\$ComputerProduct"
+            $DriverPathModel = "$($OSDCloudDriveLetter):\OSDCloud\DriverPacks\DISM\$ComputerManufacturer\$ComputerModel"
             if ($PackageID){
                 $DriverPathPackageID = "$($OSDCloudDriveLetter):\OSDCloud\DriverPacks\DISM\$ComputerManufacturer\$PackageID"
             }
@@ -39,6 +41,7 @@
                 if (Test-Path $DriverPathPackageID){$DriverPath = $DriverPathPackageID}
             }
             if (Test-Path $DriverPathProduct){$DriverPath = $DriverPathProduct}
+            if (Test-Path $DriverPathModel){$DriverPath = $DriverPathModel}
             if (Test-Path $DriverPath){
                 Write-Host "Found Drivers: $DriverPath" -ForegroundColor Green
                 Write-Host "Starting DISM of drivers while Offline" -ForegroundColor Green

--- a/Public/OSDCloudTS/Test-DISMFromOSDCloudUSB.ps1
+++ b/Public/OSDCloudTS/Test-DISMFromOSDCloudUSB.ps1
@@ -20,25 +20,25 @@
     }
     if ($OSDCloudDriveLetter){
         $ComputerProduct = (Get-MyComputerProduct)
+        $ComputerModel = (Get-MyComputerModel)
         if (!($PackageID)){
-            $PackageID = $DriverPack.PackageID
             $DriverPack = Get-OSDCloudDriverPack -Product $ComputerProduct
+            $PackageID = $DriverPack.PackageID
         }
         $ComputerManufacturer = (Get-MyComputerManufacturer -Brief)
         if ($ComputerManufacturer -match "Samsung"){$ComputerManufacturer = "Samsung"}
         $DriverPathProduct = "$($OSDCloudDriveLetter):\OSDCloud\DriverPacks\DISM\$ComputerManufacturer\$ComputerProduct"
-        $DriverPathPackageID = "$($OSDCloudDriveLetter):\OSDCloud\DriverPacks\DISM\$ComputerManufacturer\$PackageID"
-        if ($PackageID){  
-            Write-Host "Testing Paths:"
-            Write-Host "  $DriverPathProduct"
+        $DriverPathModel = "$($OSDCloudDriveLetter):\OSDCloud\DriverPacks\DISM\$ComputerManufacturer\$ComputerModel"
+        Write-Host "Testing Paths:"
+        Write-Host "  $DriverPathProduct"
+        Write-Host "  $DriverPathModel"
+        if ($PackageID){
+            $DriverPathPackageID = "$($OSDCloudDriveLetter):\OSDCloud\DriverPacks\DISM\$ComputerManufacturer\$PackageID"
             Write-Host "  $DriverPathPackageID"
-        }
-        else {
-            Write-Host "Testing Path:"
-            Write-Host "  $DriverPathProduct"
+            if (Test-Path $DriverPathPackageID){Return $true}
         }
         if (Test-Path $DriverPathProduct){Return $true}
-        elseif (Test-Path $DriverPathPackageID){Return $true}
+        elseif (Test-Path $DriverPathModel){Return $true}
         else { Return $false}
     }
     else{


### PR DESCRIPTION
Needs more testing, but this should resolve issue #181.

I've also added the option for more human readable driver paths based on ComputerModel. I realize these can be quite long for some models, but I still believe this makes offline drivers easier to manage.

![image](https://github.com/user-attachments/assets/f08a24d9-3044-4fff-8c1c-2eaa941df169)
