### PR TITLE
Fix ARM64 path handling for etfsboot.com in Get-AdkPaths function

### DIFF
--- a/Public/Functions/ADK/Get-ADKpaths.ps1
+++ b/Public/Functions/ADK/Get-ADKpaths.ps1
@@ -16,7 +16,7 @@ function Get-AdkPaths {
     [CmdletBinding()]
     param (
         [Parameter(Position = 0, ValueFromPipelineByPropertyName = $true)]
-        [ValidateSet('amd64','x86','arm64')]
+        [ValidateSet('amd64', 'x86', 'arm64')]
         [string]$Arch = $Env:PROCESSOR_ARCHITECTURE
     )
     
@@ -73,7 +73,13 @@ function Get-AdkPaths {
         dismexe             = Join-Path $PathDeploymentTools (Join-Path 'DISM' 'dism.exe')
         efisysbin           = Join-Path $PathDeploymentTools (Join-Path 'Oscdimg' 'efisys.bin')
         efisysnopromptbin   = Join-Path $PathDeploymentTools (Join-Path 'Oscdimg' 'efisys_noprompt.bin')
-        etfsbootcom         = Join-Path $PathDeploymentTools (Join-Path 'Oscdimg' 'etfsboot.com')
+        etfsbootcom         = if ($Arch -eq 'arm64') {
+            # ARM64 does not have a etfsboot.com | Redirect to amd64 folder
+            Join-Path (Join-Path $AdkRoot (Join-Path 'Deployment Tools' 'amd64')) (Join-Path 'Oscdimg' 'etfsboot.com')
+        }
+        else {
+            Join-Path $PathDeploymentTools (Join-Path 'Oscdimg' 'etfsboot.com')
+        }
         imagexexe           = Join-Path $PathDeploymentTools (Join-Path 'DISM' 'imagex.exe')
         oa3toolexe          = Join-Path $PathDeploymentTools (Join-Path 'Licensing\OA30' 'oa3tool.exe')
         oscdimgexe          = Join-Path $PathDeploymentTools (Join-Path 'Oscdimg' 'oscdimg.exe')


### PR DESCRIPTION
Resolves Issue: [https://github.com/OSDeploy/OSD/issues/189](https://github.com/OSDeploy/OSD/issues/189)

When Building a Template on an ARM64 machine, you receive the below error message.
![image](https://github.com/user-attachments/assets/bc7ee531-4ef8-4e00-8ce9-96010f59aeca)

This is because the 'etfsboot.com' file does not exist within the 'Deployment Tools\ARM64' folder.
![image](https://github.com/user-attachments/assets/9bab426f-9a00-409b-8691-b3a0404d92f2)

The 'Get-AdkPath's builds the path out expecting it to be there:
![image](https://github.com/user-attachments/assets/378bd0cb-3982-4807-b18f-e9a97c1efa12)

This fix will redirect to the AMD64 folder should an 'ARM64' parameter be passed
![image](https://github.com/user-attachments/assets/9ac08395-6092-4a9c-9615-c508156ec8b3)

