### PR TITLE
Removed GamingPeripherals

### DIFF
--- a/OSD.psd1
+++ b/OSD.psd1
@@ -2,10 +2,10 @@
 
 @{
 RootModule              = 'OSD.psm1'
-ModuleVersion           = '25.1.26.3'
+ModuleVersion           = '25.1.28.1'
 CompatiblePSEditions    = @('Desktop')
 GUID                    = '9fe5b9b6-0224-4d87-9018-a8978529f6f5'
-Author                  = 'David Segura . Gary Blok . Akos Bakos'
+Author                  = 'David Segura . Gary Blok . Akos Bakos . Michael Escamilla'
 CompanyName             = 'OSD Community'
 Copyright               = '(c) 2025 OSDeploy'
 Description             = @'

--- a/Private/Copy-OSDCloud.media.ps1
+++ b/Private/Copy-OSDCloud.media.ps1
@@ -97,7 +97,7 @@ function Copy-OSDCloud.media {
     Add-WindowsPackage -Path $MountPath -PackagePath "$WinPEOCs\WinPE-EnhancedStorage.cab"
     Add-WindowsPackage -Path $MountPath -PackagePath "$WinPEOCs\en-us\WinPE-EnhancedStorage_en-us.cab"
     Add-WindowsPackage -Path $MountPath -PackagePath "$WinPEOCs\WinPE-FMAPI.cab"
-    Add-WindowsPackage -Path $MountPath -PackagePath "$WinPEOCs\WinPE-GamingPeripherals.cab"
+    # Add-WindowsPackage -Path $MountPath -PackagePath "$WinPEOCs\WinPE-GamingPeripherals.cab"
     Add-WindowsPackage -Path $MountPath -PackagePath "$WinPEOCs\WinPE-PPPoE.cab"
     Add-WindowsPackage -Path $MountPath -PackagePath "$WinPEOCs\en-us\WinPE-PPPoE_en-us.cab"
     Add-WindowsPackage -Path $MountPath -PackagePath "$WinPEOCs\WinPE-PlatformId.cab"

--- a/Public/Functions/ADK/Edit-AdkWinPEWIM.ps1
+++ b/Public/Functions/ADK/Edit-AdkWinPEWIM.ps1
@@ -86,7 +86,7 @@ function Edit-AdkWinPEWIM {
     Add-WindowsPackage -Path $MountPath -PackagePath "$WinPEOCs\WinPE-EnhancedStorage.cab"
     Add-WindowsPackage -Path $MountPath -PackagePath "$WinPEOCs\en-us\WinPE-EnhancedStorage_en-us.cab"
     Add-WindowsPackage -Path $MountPath -PackagePath "$WinPEOCs\WinPE-FMAPI.cab"
-    Add-WindowsPackage -Path $MountPath -PackagePath "$WinPEOCs\WinPE-GamingPeripherals.cab"
+    # Add-WindowsPackage -Path $MountPath -PackagePath "$WinPEOCs\WinPE-GamingPeripherals.cab"
     Add-WindowsPackage -Path $MountPath -PackagePath "$WinPEOCs\WinPE-PPPoE.cab"
     Add-WindowsPackage -Path $MountPath -PackagePath "$WinPEOCs\en-us\WinPE-PPPoE_en-us.cab"
     Add-WindowsPackage -Path $MountPath -PackagePath "$WinPEOCs\WinPE-PlatformId.cab"

--- a/Public/OSDCloudSetup/OSDCloudTemplate.ps1
+++ b/Public/OSDCloudSetup/OSDCloudTemplate.ps1
@@ -556,7 +556,7 @@ Windows Registry Editor Version 5.00
         'Dot3Svc'
         'EnhancedStorage'
         'FMAPI'
-        'GamingPeripherals'
+        #'GamingPeripherals'
         'HSP-Driver'
         'PPPoE'
         'PlatformId'


### PR DESCRIPTION
When adding to WinPE
WinPE-GamingPeripherals.cab was causing Add-WindowsPackage failed.
Error code = 0x80070003

This causes the WinPE Image to be unserviceable.

First noticed in WinPE 10.0.26100.2876