### PR TITLE
Variable to Disable SetupComplete Restart

### DIFF
--- a/Public/OSDCloud.ps1
+++ b/Public/OSDCloud.ps1
@@ -178,6 +178,7 @@
         ScriptStartup = $null
         ScriptShutdown = $null
         SectionPassed = $true
+        SetupCompleteNoRestart = [bool]$false
         SetWiFi = $null
         Shutdown = [bool]$false
         ShutdownSetupComplete = [bool]$false
@@ -2262,7 +2263,13 @@ exit
     }
 
     #This appends the two lines at the end of SetupComplete Script to Stop Transcription and to Restart Computer
-    Set-SetupCompleteCreateFinish
+    if ($SetupCompleteNoRestart -eq $true) {
+        Set-SetupCompleteCreateFinish -NoRestart
+    }
+    else {
+        Set-SetupCompleteCreateFinish
+    }
+    
     #endregion
 
     #region ----- Config Shutdown Scripts

--- a/Public/OSDCloud.ps1
+++ b/Public/OSDCloud.ps1
@@ -2263,7 +2263,8 @@ exit
     }
 
     #This appends the two lines at the end of SetupComplete Script to Stop Transcription and to Restart Computer
-    if ($SetupCompleteNoRestart -eq $true) {
+    if ($Global:OSDCloud.SetupCompleteNoRestart -eq $true) {
+        Write-DarkGrayHost "[i] SetupCompleteNoRestart from Global Variable `$Global:OSDCloud.SetupComplete is set to $($Global:OSDCloud.SetupCompleteNoRestart)"
         Set-SetupCompleteCreateFinish -NoRestart
     }
     else {

--- a/Public/OSDCloudTS/Set-SetupCompleteCreateFinish.ps1
+++ b/Public/OSDCloudTS/Set-SetupCompleteCreateFinish.ps1
@@ -23,13 +23,16 @@
             Add-Content -Path $PSFilePath "Stop-Computer -Force"
         }
         else {
-            Add-Content -Path $PSFilePath "Stop-Transcript"
-            if (!($NoRestart)) {
+            if ($NoRestart) {
+                Add-Content -Path $PSFilePath "Write-Output 'SetupCompleteNoRestart enabled, Not Restarting Device'"
+                Add-Content -Path $PSFilePath "Stop-Transcript"
+            } else {
+                Add-Content -Path $PSFilePath "Stop-Transcript"
                 Add-Content -Path $PSFilePath "Restart-Computer -Force"
             }
         }
-        else {
-            Write-Output "$PSFilePath - Not Found"
-        }
+    }
+    else {
+        Write-Output "$PSFilePath - Not Found"
     }
 }

--- a/Public/OSDCloudTS/Set-SetupCompleteCreateFinish.ps1
+++ b/Public/OSDCloudTS/Set-SetupCompleteCreateFinish.ps1
@@ -1,28 +1,35 @@
 ﻿function Set-SetupCompleteCreateFinish {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.SwitchParameter]
+        $NoRestart
+    )
 
     $ScriptsPath = "C:\Windows\Setup\scripts"
-    $RunScript = @(@{ Script = "SetupComplete"; BatFile = 'SetupComplete.cmd'; ps1file = 'SetupComplete.ps1';Type = 'Setup'; Path = "$ScriptsPath"})
+    $RunScript = @(@{ Script = "SetupComplete"; BatFile = 'SetupComplete.cmd'; ps1file = 'SetupComplete.ps1'; Type = 'Setup'; Path = "$ScriptsPath" })
     $PSFilePath = "$($RunScript.Path)\$($RunScript.ps1File)"
 
-    if (Test-Path -Path $PSFilePath){
+    if (Test-Path -Path $PSFilePath) {
         Add-Content -Path $PSFilePath "Write-Output 'Setting PowerPlan to Balanced'"
         Add-Content -Path $PSFilePath "Set-PowerSettingTurnMonitorOffAfter -PowerSource AC -Minutes 15"
         Add-Content -Path $PSFilePath "powercfg /setactive 381B4222-F694-41F0-9685-FF5BB260DF2E"
         Add-Content -Path $PSFilePath '$EndTime = Get-date; Write-Host "End Time: $($EndTime.ToString("hh:mm:ss"))"'
         Add-Content -Path $PSFilePath '$TotalTime = New-TimeSpan -Start $StartTime -End $EndTime; $RunTimeMinutes = [math]::round($TotalTime.TotalMinutes,0); Write-Host "Run Time: $RunTimeMinutes Minutes"'
         
-        if ($Global:OSDCloud.ShutdownSetupComplete -eq $true){
+        if ($Global:OSDCloud.ShutdownSetupComplete -eq $true) {
             Add-Content -Path $PSFilePath "Write-Output 'ShutdownSetupComplete enabled, Shutting down Device'"
             Add-Content -Path $PSFilePath "Stop-Transcript"
             Add-Content -Path $PSFilePath "Stop-Computer -Force"
         }
         else {
             Add-Content -Path $PSFilePath "Stop-Transcript"
-            Add-Content -Path $PSFilePath "Restart-Computer -Force"
+            if (!($NoRestart)) {
+                Add-Content -Path $PSFilePath "Restart-Computer -Force"
+            }
+        }
+        else {
+            Write-Output "$PSFilePath - Not Found"
         }
     }
-    else {
-    Write-Output "$PSFilePath - Not Found"
-    }
-
 }


### PR DESCRIPTION
I've seen a few request to be able to have SetupComplete NOT reboot at the end.

![image](https://github.com/user-attachments/assets/43d38ffb-c009-45aa-bc7d-83e3956ec434)

![image](https://github.com/user-attachments/assets/b7cdc20f-c76a-4fc2-8ec4-4d5ccc27a616)

![image](https://github.com/user-attachments/assets/d6d5cc8b-5b67-4e22-9582-3d18280e7eaa)
