### PR TITLE
Set SyncMSUpCatDriverUSB form control from Global variable on load

### DIFF
--- a/Projects/OSDCloudGUI/MainWindow.ps1
+++ b/Projects/OSDCloudGUI/MainWindow.ps1
@@ -396,16 +396,22 @@ else{
 #$formMainWindowControlWindowsDefenderUpdate.Visibility = 'Hidden'
 #$formMainWindowControlWindowsDefenderUpdate.IsEnabled = $false
 #================================================
-#   Menu Options
+#   Menu Options - Deployment Options
 #================================================
 $formMainWindowControlcaptureScreenshots.IsChecked = $Global:OSDCloudGUI.captureScreenshots
 $formMainWindowControlClearDiskConfirm.IsChecked = $Global:OSDCloudGUI.ClearDiskConfirm
 $formMainWindowControlrestartComputer.IsChecked = $Global:OSDCloudGUI.restartComputer
+#================================================
+#   Menu Options - Microsoft Update Catalog
+#================================================
 $formMainWindowControlupdateDiskDrivers.IsChecked = $Global:OSDCloudGUI.updateDiskDrivers
 $formMainWindowControlupdateFirmware.IsChecked = $Global:OSDCloudGUI.updateFirmware
 $formMainWindowControlupdateNetworkDrivers.IsChecked = $Global:OSDCloudGUI.updateNetworkDrivers
 $formMainWindowControlupdateSCSIDrivers.IsChecked = $Global:OSDCloudGUI.updateSCSIDrivers
-
+$formMainWindowControlSyncMSUpCatDriverUSB.IsChecked = $Global:OSDCloudGUI.SyncMSUpCatDriverUSB
+#================================================
+#   Menu Options - SetupComplete Options
+#================================================
 $formMainWindowControlWindowsDefenderUpdate.IsChecked = $Global:OSDCloudGUI.WindowsDefenderUpdate
 $formMainWindowControlWindowsUpdates.IsChecked = $Global:OSDCloudGUI.WindowsUpdate
 $formMainWindowControlWindowsUpdateDrivers.IsChecked = $Global:OSDCloudGUI.WindowsUpdateDrivers

--- a/Public/Start-OSDCloudGUI.ps1
+++ b/Public/Start-OSDCloudGUI.ps1
@@ -76,16 +76,17 @@
         captureScreenshots          = [System.Boolean]$Global:OSDModuleResource.StartOSDCloudGUI.captureScreenshots
         ClearDiskConfirm            = [System.Boolean]$Global:OSDModuleResource.StartOSDCloudGUI.ClearDiskConfirm
         restartComputer             = [System.Boolean]$Global:OSDModuleResource.StartOSDCloudGUI.restartComputer
+        
         updateDiskDrivers           = [System.Boolean]$Global:OSDModuleResource.StartOSDCloudGUI.updateDiskDrivers
         updateFirmware              = [System.Boolean]$Global:OSDModuleResource.StartOSDCloudGUI.updateFirmware
         updateNetworkDrivers        = [System.Boolean]$Global:OSDModuleResource.StartOSDCloudGUI.updateNetworkDrivers
         updateSCSIDrivers           = [System.Boolean]$Global:OSDModuleResource.StartOSDCloudGUI.updateSCSIDrivers
+        SyncMSUpCatDriverUSB        = [System.Boolean]$Global:OSDModuleResource.StartOSDCloudGUI.SyncMSUpCatDriverUSB
 
         OEMActivation               = [System.Boolean]$Global:OSDModuleResource.StartOSDCloudGUI.OEMActivation
         WindowsUpdate               = [System.Boolean]$Global:OSDModuleResource.StartOSDCloudGUI.WindowsUpdate
         WindowsUpdateDrivers        = [System.Boolean]$Global:OSDModuleResource.StartOSDCloudGUI.WindowsUpdateDrivers
         WindowsDefenderUpdate       = [System.Boolean]$Global:OSDModuleResource.StartOSDCloudGUI.WindowsDefenderUpdate
-        SyncMSUpCatDriverUSB        = [System.Boolean]$Global:OSDModuleResource.StartOSDCloudGUI.SyncMSUpCatDriverUSB
 
         HPIAALL                     = [System.Boolean]$Global:OSDModuleResource.StartOSDCloudGUI.HPIAALL
         HPIADrivers                 = [System.Boolean]$Global:OSDModuleResource.StartOSDCloudGUI.HPIADrivers


### PR DESCRIPTION
The 'Sync MS drivers to USB' menu option was not being set based on the value in the $Global:OSDCloudGUI variable (Start-OSDCloudGUI.json).

Added that to the MainWindow.ps1

Group the form variables up for easier viewing.

Tested on a physical dell machine with the setting selected and unselected and appears to work OK.

With the fix in place
![image](https://github.com/user-attachments/assets/1ec01408-a781-4421-8cfa-5ccb2f8c31e3)

Original Problem
![image](https://github.com/user-attachments/assets/c17e2e26-b636-45d4-b95b-1b0b0a9259ea)


