### PR TITLE
Rectify inability to override ComputerProduct and DriverPackName in Start-OSDCloudGUI.json

### DIFF
--- a/Public/Start-OSDCloudGUI.ps1
+++ b/Public/Start-OSDCloudGUI.ps1
@@ -141,8 +141,8 @@
     #   New logic added to Get-OSDCloudDriverPack
     #   This should match the proper OS Version ReleaseID
     #================================================
-    $Global:OSDCloudGUI.DriverPack = Get-OSDCloudDriverPack -Product $ComputerProduct -OSVersion $Global:OSDCloudGUI.OSVersion -OSReleaseID $Global:OSDCloudGUI.OSReleaseID
-    if ($Global:OSDCloudGUI.DriverPack) {
+    $Global:OSDCloudGUI.DriverPack = Get-OSDCloudDriverPack -Product $Global:OSDCloudGUI.ComputerProduct -OSVersion $Global:OSDCloudGUI.OSVersion -OSReleaseID $Global:OSDCloudGUI.OSReleaseID
+    if ($Global:OSDCloudGUI.DriverPack -and $null -ne $Global:OSDCloudGUI.DriverPackName) {
         $Global:OSDCloudGUI.DriverPackName = $Global:OSDCloudGUI.DriverPack.Name
     }
     #=================================================


### PR DESCRIPTION
- Use $Global:OSDCloudGUI.ComputerProduct in Get-OSDCloudDriverPack rather than $ComputerProduct
- Only set DriverPackName if $Global:OSDCloudGUI.DriverPackName is $null