### PR TITLE
Update Select-OSDCloudFileWim.ps1

### DIFF
--- a/Public/OSDCloudTS/Select-OSDCloudFileWim.ps1
+++ b/Public/OSDCloudTS/Select-OSDCloudFileWim.ps1
@@ -48,6 +48,6 @@ function Select-OSDCloudFileWim {
         Return Get-Item (Join-Path $Results.Directory $Results.Name)
     
     } ElseIf ($Results.Count -eq 1) {
-        Return $Results.FullName
+        Return $Results
     }
 }


### PR DESCRIPTION
Added an 'ElseIf' so the image gets automatically selected if there is only one file found. This is useful when running OSDCloud with the 'ZTI' parameter and without user interaction.