### PR TITLE
Fix Wi-Fi not working when spaces in SSID

### DIFF
--- a/Public/OSDCloudTS/Set-SetupCompleteSetWiFi.ps1
+++ b/Public/OSDCloudTS/Set-SetupCompleteSetWiFi.ps1
@@ -14,8 +14,8 @@ function Set-SetupCompleteSetWiFi {
             $PSK = $Json.Addons.PSK
             if (Test-Path -Path $PSFilePath){
                 Add-Content -Path $PSFilePath ' Write-Host "Creating WiFi Profile"'
-                Write-Host " Set-WiFi -SSID $SSID -PSK ***********"
-                Add-Content -Path $PSFilePath "Set-WiFi -SSID $SSID -PSK $PSK"
+                Write-Host "Set-WiFi -SSID `"$SSID`" -PSK `"***********`""
+                Add-Content -Path $PSFilePath "Set-WiFi -SSID `"$SSID`" -PSK `"$PSK`""
                 Add-Content -Path $PSFilePath "Remove-Item -Path $ConfigPath\WiFi.JSON -Force -Verbose"
                 Add-Content -Path $PSFilePath "Write-Output '-------------------------------------------------------------'"
             }


### PR DESCRIPTION
Added quotes to the Set-Wifi command called in SetupComplete so it will work properly when there are spaces in the SSID.
This fixes #265.