### PR TITLE
Reposted : Add Support for Offline Catalog Files in OSD (Feature/support_offline_catalog)

### DIFF
--- a/Public/Functions/Other/Save-WebFile.ps1
+++ b/Public/Functions/Other/Save-WebFile.ps1
@@ -116,13 +116,17 @@ function Save-WebFile {
         else {
             Write-Verbose "cURL Source: $SourceUrl"
             Write-Verbose "Destination: $DestinationFullName"
-    
-            if ($host.name -match 'ConsoleHost') {
-                Invoke-Expression "& curl.exe --insecure --location --output `"$DestinationFullName`" --url `"$SourceUrl`""
-            }
-            else {
-                #PowerShell ISE will display a NativeCommandError, so progress will not be displayed
-                $Quiet = Invoke-Expression "& curl.exe --insecure --location --output `"$DestinationFullName`" --url `"$SourceUrl`" 2>&1"
+            $Headers = Invoke-Expression "& curl.exe --head --silent --insecure --location --url `"$SourceUrl`""
+            if ($Headers[0] -match "200.+OK") {
+                if ($host.name -match 'ConsoleHost') {
+                    Invoke-Expression "& curl.exe --insecure --location --output `"$DestinationFullName`" --url `"$SourceUrl`""
+                }
+                else {
+                    #PowerShell ISE will display a NativeCommandError, so progress will not be displayed
+                    $Quiet = Invoke-Expression "& curl.exe --insecure --location --output `"$DestinationFullName`" --url `"$SourceUrl`" 2>&1"
+                }
+            } else {
+                Write-Warning "Header status: $($headers[0])"
             }
         }
         #=================================================

--- a/Public/OSDCloudDriverPack/OSDCloud.DriverPack.ps1
+++ b/Public/OSDCloudDriverPack/OSDCloud.DriverPack.ps1
@@ -67,7 +67,17 @@ function Get-OSDCloudDriverPacks {
     #>
     [CmdletBinding()]
     param ()
-    $Results = Import-Clixml -Path "$(Get-OSDModulePath)\cache\driverpack-catalogs\build-driverpacks.xml"
+    $DriverCatalogXML = Get-PSDrive -PSProvider FileSystem | Where-Object {$_.Name -ne 'C'} | ForEach-Object {
+        Get-ChildItem "$($_.Root)OSDCloud\Catalogs" -Include "build-driverpacks.xml" -File -Force -Recurse -ErrorAction Ignore
+    }
+    if ($DriverCatalogXML) {
+        foreach ($Item in $DriverCatalogXML) {
+            Write-Warning "$($Item.FullName) is imported instead of the cache under $(Get-OSDModulePath)."
+            $Results = Import-Clixml -Path $Item.FullName
+        }
+    } else {
+        $Results = Import-Clixml -Path "$(Get-OSDModulePath)\cache\driverpack-catalogs\build-driverpacks.xml"
+    }
     $Results
 }
 function Save-OSDCloudDriverPack {

--- a/Public/OSDCloudSetup/OSDCloudTemplate.ps1
+++ b/Public/OSDCloudSetup/OSDCloudTemplate.ps1
@@ -1014,7 +1014,8 @@ Windows Registry Editor Version 5.00
         'Config\Scripts\SetupComplete',
         'Config\Scripts\Shutdown',
         'Config\Scripts\Startup',
-        'Config\Scripts\StartNet'
+        'Config\Scripts\StartNet',
+        'Config\Scripts\StartNet2'
     )
     
     if ($Name -match 'public') {

--- a/Public/OSDCloudTS/Get-OSDCloudOperatingSystemsIndexes.ps1
+++ b/Public/OSDCloudTS/Get-OSDCloudOperatingSystemsIndexes.ps1
@@ -19,10 +19,30 @@ function Get-OSDCloudOperatingSystemsIndexes {
     )
 
     if ($OSArch -eq 'x64') {
-        $Results = Get-Content -Path "$(Get-OSDModulePath)\cache\archive-cloudoperatingsystems\CloudOperatingSystemsIndexes.json" | ConvertFrom-Json
+        $OfflineCatalog = Get-PSDrive -PSProvider FileSystem | Where-Object {$_.Name -ne 'C'} | ForEach-Object {
+            Get-ChildItem "$($_.Root)OSDCloud\Catalogs" -Include "CloudOperatingSystemsIndexes.json" -File -Force -Recurse -ErrorAction Ignore
+        }
+        if ($OfflineCatalog) {
+            foreach ($Item in $OfflineCatalog) {
+                Write-Warning "$($Item.FullName) is imported instead of the cache under $(Get-OSDModulePath)."
+                $Results = Get-Content -Path "$($Item.FullName)" | ConvertFrom-Json -ErrorAction "Stop"
+            }
+        } else {
+            $Results = Get-Content -Path "$(Get-OSDCachePath)\archive-cloudoperatingsystems\CloudOperatingSystemsIndexes.json" | ConvertFrom-Json
+        }
     }
     elseif ($OSArch -eq "ARM64") {
-        $Results = Get-Content -Path "$(Get-OSDModulePath)\cache\archive-cloudoperatingsystems\CloudOperatingSystemsARM64Indexes.json" | ConvertFrom-Json
+        $OfflineCatalog = Get-PSDrive -PSProvider FileSystem | Where-Object {$_.Name -ne 'C'} | ForEach-Object {
+            Get-ChildItem "$($_.Root)OSDCloud\Catalogs" -Include "CloudOperatingSystemsARM64Indexes.json" -File -Force -Recurse -ErrorAction Ignore
+        }
+        if ($OfflineCatalog) {
+            foreach ($Item in $OfflineCatalog) {
+                Write-Warning "$($Item.FullName) is imported instead of the cache under $(Get-OSDModulePath)."
+                $Results = Get-Content -Path "$($Item.FullName)" | ConvertFrom-Json -ErrorAction "Stop"
+            }
+        } else {
+            $Results = Get-Content -Path "$(Get-OSDCachePath)\archive-cloudoperatingsystems\CloudOperatingSystemsARM64Indexes.json" | ConvertFrom-Json
+        }
     }
 
     return $Results


### PR DESCRIPTION
## Summary　(Revised on 9/15/2025)

This pull request consolidates previous commits and introduces a comprehensive revision to improve clarity and maintainability. It adds support for using **custom offline catalog files** in OSD deployments, along with enhancements to **post-network initialization** and **module update control**.

These changes provide greater flexibility for enterprise IT teams to customize the OSD environment. At the same time, when automatic module updates are suppressed, IT teams must take responsibility for maintaining catalog files manually.

---

## Background

These patches are designed for scenarios involving `Start-OSDCloudGUI`.

The OSD module published to the PowerShell Gallery is automatically updated up to four times a day, including refreshed OS and DriverPack catalog files (JSON/XML) stored in the cache folder. Because these catalogs are bundled with the module, running `Import-Module -Force` by default updates both the PowerShell scripts and the catalog files.

This automation makes it difficult for enterprise IT teams to customize and test the OSD module, as any local modifications are overwritten by the latest version from the PowerShell Gallery.

To address this, the update introduces mechanisms to override default catalogs and suppress automatic module updates.

---

## Key Enhancements

### 1. Offline Catalog Override  
**Affected files**:  
- `Get-OSDCloudDriverPacks.ps1`  
- `Get-OSDCloudOperatingSystems.ps1`  
- `Get-OSDCloudOperatingSystemsIndexMap.ps1`  
- `Get-OSDCloudOperatingSystemsIndexes.ps1`

When the `USB\OSDCloud\Catalogs` folder is present, these patched scripts prioritize user-defined catalog files over the default cache.

---

### 2. URL Validation via `curl`  
**Affected file**:  
- `Save-WebFile.ps1`

To ensure reliability, a validation step checks the accessibility of URLs in custom catalogs using `curl`. This helps prevent deployment failures due to outdated or unreachable resources.

---

### 3. Post-Network Script Execution & Suppression of Auto Module Update  
**Affected files**:  
- `Initialize-OSDCloudStartnet.ps1`  
- `OSDCloudTemplate.ps1`

- A custom PowerShell script can now be executed after a network connection is established (Wi-Fi or Ethernet).
- The script location is defined via a new template variable pointing to `OSDCloud\Config\StartNet2`.
- Automatic module updates can be disabled by setting `"OSDAutoUpdate": false` in `OSDCloud\Config\Initialize-OSDCloudStartnet.json`.

These features allow enterprise IT teams to maintain control over catalog sources and deployment behavior.

---

### 4. Non-Intrusive Design

All enhancements are opt-in. Default behavior remains unchanged unless the relevant folders or configuration files are explicitly provided, ensuring full backward compatibility.

---

## Integration Notes

This PR includes cherry-picked changes from [PR #288](https://github.comintegration with existing startup logic.

---

## Revision History

| Date       | Description                                      |
|------------|--------------------------------------------------|
| 2025-07-21 | cherry-picked  feature/InintStartNet2 (PR:#288), for integration |
| 2025-09-15 | revised with consolidated commits and full rewrite of PR description |
