### PR TITLE
Enable post-network script execution and optionally suppress module auto-updates (Initialize-OSDCloudStartnet.ps1)

### DIFF
--- a/Public/OSDCloudSetup/OSDCloudTemplate.ps1
+++ b/Public/OSDCloudSetup/OSDCloudTemplate.ps1
@@ -1014,7 +1014,8 @@ Windows Registry Editor Version 5.00
         'Config\Scripts\SetupComplete',
         'Config\Scripts\Shutdown',
         'Config\Scripts\Startup',
-        'Config\Scripts\StartNet'
+        'Config\Scripts\StartNet',
+        'Config\Scripts\StartNet2'
     )
     
     if ($Name -match 'public') {


### PR DESCRIPTION
## Summary
This PR introduces two enhancements to the OSDCloudStartnet initialization process:

1. **Post-Network Script Execution**  
   A custom PowerShell script can now be executed after a network connection is established.  
   - Supports execution after establishing either Wi-Fi or wired (Ethernet) connections 
   - Script location is defined via a new template variable pointing to the `OSDCloud\Config\StarNet2` folder

2. **Optional Suppression of Module Auto-Update**  
   The automatic update of OSD modules can now be disabled by setting `{ "OSDAutoUpdate": false }` in  
   `OSDCloud\Config\Initialize-OSDCloudStartnet.json`.  
   - If the setting is omitted, the default behavior (auto-update enabled) is preserved.  
   - This prevents customizations in OSD modules from being overwritten by `Import-Module -Force`, ensuring consistent behavior in customized environments.

## Motivation
These changes provide greater control and flexibility during the early stages of OSDCloud initialization, especially in environments where deterministic behavior or offline operation is required.

A typical use case involves hosting pre-validated catalog files of company standard device models on external storage (e.g., Azure Blob) and downloading them during initialization. This approach avoids relying on the generic catalogs bundled with the latest module versions, which—while always up-to-date—may not reflect the specific validation or optimization required for certain hardware models. Suppressing automatic updates helps preserve these curated configurations and ensures consistent deployment behavior.

## Notes
- Backward compatible: no impact on existing templates unless the new features are explicitly used.

## EDIT (7/21/2025)
feature/support_offline_Catalog (PR:https://github.com/OSDeploy/OSD/pull/284) cherry-picked this PR for integration.