### PR TITLE
Fix bug for $ in WiFi-passwords

### DIFF
--- a/Public/OSDCloudTS/Set-SetupCompleteSetWiFi.ps1
+++ b/Public/OSDCloudTS/Set-SetupCompleteSetWiFi.ps1
@@ -15,7 +15,7 @@ function Set-SetupCompleteSetWiFi {
             if (Test-Path -Path $PSFilePath){
                 Add-Content -Path $PSFilePath ' Write-Host "Creating WiFi Profile"'
                 Write-Host " Set-WiFi -SSID $SSID -PSK ***********"
-                Add-Content -Path $PSFilePath "Set-WiFi -SSID $SSID -PSK $PSK"
+                Add-Content -Path $PSFilePath "Set-WiFi -SSID $SSID -PSK '$PSK'"
                 Add-Content -Path $PSFilePath "Remove-Item -Path $ConfigPath\WiFi.JSON -Force -Verbose"
                 Add-Content -Path $PSFilePath "Write-Output '-------------------------------------------------------------'"
             }


### PR DESCRIPTION
This fix aims to solve incompatibility of $ inside Wifi-Passwords. I have narrowed down the errors we have experienced with one particular WiFi network to stem from this line in the code.

I considered just overriding Start-OSDCloudGUI.json to intentionally prevent OSDCloud from applying this configuration, but I suspect that this would end up not working for other reasons.