### PR TITLE
Refactor OSDCloud and Start-OSDCloud scripts to streamline OS image handling

### DIFF
--- a/Public/OSDCloud.ps1
+++ b/Public/OSDCloud.ps1
@@ -890,7 +890,7 @@
                 $Global:OSDCloud.GetFeatureUpdate = $Global:OSDCloud.GetFeatureUpdate | Select-Object -Property CreationDate,KBNumber,Title,UpdateOS,UpdateBuild,UpdateArch,FileName, @{Name='SizeMB';Expression={[int]($_.Size /1024/1024)}},FileUri,Hash,AdditionalHash
                 $Global:OSDCloud.ImageFileName = $Global:OSDCloud.GetFeatureUpdate.FileName
                 $Global:OSDCloud.ImageFileUrl = $Global:OSDCloud.GetFeatureUpdate.FileUri
-                $Global:OSDCloud.OSImageIndex = 6
+                # $Global:OSDCloud.OSImageIndex = 6
             }
             else {
                 Write-Warning "[$(Get-Date -format G)] OSDCloud Failed"
@@ -1106,8 +1106,8 @@
                 Stop-Computer -Force
                 Exit
             }
-
-            #TODO: Make sure the ImageIndex is 1
+            #=================================================
+            # Is there only one ImageIndex?
             elseif ($Global:OSDCloud.WindowsImageCount -eq 1) {
                 $Global:OSDCloud.OSImageIndex = 1
             }
@@ -1123,6 +1123,7 @@
                 $Global:OSDCloud.OSImageIndex = 'AUTO'
             }
 
+            <#
             if ($Global:OSDCloud.OSImageIndex -ne 'AUTO') {
                 #Home Single Language Correction
                 if (($OSActivation -eq 'Retail') -and ($Global:OSDCloud.WindowsImageCount -eq 9)) {
@@ -1142,6 +1143,7 @@
                     }
                 }
             }
+            #>
         }
         else {
             #=================================================
@@ -1152,6 +1154,18 @@
             Write-Warning "Press Ctrl+C to exit"
             Start-Sleep -Seconds 86400
             Exit
+        }
+
+        if ($Global:OSDCloud.OSImageIndex -eq 'AUTO') {
+            if ($Global:OSDCloud.OSEditionId) {
+                $MatchingWindowsImage = $Global:OSDCloud.WindowsImage | `
+                    ForEach-Object { Get-WindowsImage -ImagePath $Global:OSDCloud.ImageFileDestination.FullName -Index $_.ImageIndex } | `
+                    Where-Object { $_.EditionId -eq $Global:OSDCloud.OSEditionId }
+            }
+                
+            if ($MatchingWindowsImage -and $MatchingWindowsImage.Count -eq 1) {
+                $Global:OSDCloud.OSImageIndex = $MatchingWindowsImage.ImageIndex
+            }
         }
 
         if ($Global:OSDCloud.OSImageIndex -eq 'AUTO') {

--- a/Public/Start-OSDCloud.ps1
+++ b/Public/Start-OSDCloud.ps1
@@ -50,10 +50,9 @@
 
         [Parameter(ParameterSetName = 'Default')]
         [ValidateSet(
-            'Windows 11 24H2 x64', 
-            'Windows 11 23H2 x64',    
+            'Windows 11 24H2 x64',
+            'Windows 11 23H2 x64',
             'Windows 11 22H2 x64',
-            'Windows 11 21H2 x64',
             'Windows 10 22H2 x64')]
         [System.String]
         $OSName,
@@ -67,7 +66,7 @@
         #Operating System Build of the Windows installation
         #Alias = Build
         [Parameter(ParameterSetName = 'Legacy')]
-        [ValidateSet('24H2','23H2','22H2','21H2')]
+        [ValidateSet('24H2','23H2','22H2')]
         [Alias('Build')]
         [System.String]
         $OSBuild,
@@ -120,10 +119,7 @@
         [Parameter(ParameterSetName = 'CustomImage')]
         [Alias('ImageIndex')]
         [System.String]
-        $OSImageIndex = 'AUTO',
-
-        [System.Management.Automation.SwitchParameter]
-        $Preview
+        $OSImageIndex = 'AUTO'
     )
     #=================================================
     #	$Global:StartOSDCloud
@@ -172,7 +168,7 @@
         OSLanguageNames = $null
         OSName = $OSName
         OSNameMenu = $null
-        OSNames = @('Windows 11 24H2 x64', 'Windows 11 23H2 x64', 'Windows 11 22H2 x64', 'Windows 11 21H2 x64', 'Windows 10 22H2 x64')
+        OSNames = @('Windows 11 24H2 x64', 'Windows 11 23H2 x64', 'Windows 11 22H2 x64', 'Windows 10 22H2 x64')
         OSVersion = $OSVersion
         OSVersionMenu = $null
         OSVersionNames = @('Windows 11','Windows 10')
@@ -195,6 +191,12 @@
         $Global:StartOSDCloud.MSCatalogFirmware = $true
     }
     #=================================================
+    #	Block
+    #=================================================
+    Block-StandardUser
+    Block-PowerShellVersionLt5
+    Block-NoCurl
+    #=================================================
     #	$Global:StartOSDCloudGUI
     #=================================================
     if ($Global:StartOSDCloudGUI) {
@@ -206,12 +208,6 @@
     if ($Global:StartOSDCloud.OSLicense) {
         $Global:StartOSDCloud.OSActivation = $Global:StartOSDCloud.OSLicense
     }
-    #=================================================
-    #	Block
-    #=================================================
-    Block-StandardUser
-    Block-PowerShellVersionLt5
-    Block-NoCurl
     #=================================================
     #	-Screenshot
     #=================================================
@@ -319,7 +315,7 @@
         if ($Global:StartOSDCloud.OSName) {
         }
         elseif ($Global:StartOSDCloud.ZTI) {
-            $Global:StartOSDCloud.OSName = 'Windows 11 22H2 x64'
+            $Global:StartOSDCloud.OSName = 'Windows 11 24H2 x64'
         }
         else {
             Write-Host -ForegroundColor DarkGray "========================================================================="
@@ -393,7 +389,7 @@
         else {
             Write-Host -ForegroundColor DarkGray "========================================================================="
             Write-Host -ForegroundColor Cyan "[$(Get-Date -format G)] Select a Build for $OSVersion x64"
-            $Global:StartOSDCloud.OSBuildNames = @('24H2','23H2','22H2','21H2')
+            $Global:StartOSDCloud.OSBuildNames = @('24H2','23H2','22H2')
             
             $i = $null
             $Global:StartOSDCloud.OSBuildMenu = foreach ($Item in $Global:StartOSDCloud.OSBuildNames) {
@@ -457,27 +453,34 @@
         if ($Global:StartOSDCloud.OSEdition -eq 'Home') {
             $Global:StartOSDCloud.OSEditionId = 'Core'
             $Global:StartOSDCloud.OSActivation = 'Retail'
-            $Global:StartOSDCloud.OSImageIndex = 4 #Confirmed 24.3.12 - GWB
         }
         if ($Global:StartOSDCloud.OSEdition -eq 'Home N') {
             $Global:StartOSDCloud.OSEditionId = 'CoreN'
             $Global:StartOSDCloud.OSActivation = 'Retail'
-            $Global:StartOSDCloud.OSImageIndex = 5
         }
         if ($Global:StartOSDCloud.OSEdition -eq 'Home Single Language') {
             $Global:StartOSDCloud.OSEditionId = 'CoreSingleLanguage'
             $Global:StartOSDCloud.OSActivation = 'Retail'
-            $Global:StartOSDCloud.OSImageIndex = 6
+        }
+        if ($Global:StartOSDCloud.OSEdition -eq 'Education') {
+            $Global:StartOSDCloud.OSEditionId = 'Education'
+        }
+        if ($Global:StartOSDCloud.OSEdition -eq 'Education N') {
+            $Global:StartOSDCloud.OSEditionId = 'EducationN'
+        }
+        if ($Global:StartOSDCloud.OSEdition -eq 'Pro') {
+            $Global:StartOSDCloud.OSEditionId = 'Professional'
+        }
+        if ($Global:StartOSDCloud.OSEdition -eq 'Pro N') {
+            $Global:StartOSDCloud.OSEditionId = 'ProfessionalN'
         }
         if ($Global:StartOSDCloud.OSEdition -eq 'Enterprise') {
             $Global:StartOSDCloud.OSEditionId = 'Enterprise'
             $Global:StartOSDCloud.OSActivation = 'Volume'
-            $Global:StartOSDCloud.OSImageIndex = 6
         }
         if ($Global:StartOSDCloud.OSEdition -eq 'Enterprise N') {
             $Global:StartOSDCloud.OSEditionId = 'EnterpriseN'
             $Global:StartOSDCloud.OSActivation = 'Volume'
-            $Global:StartOSDCloud.OSImageIndex = 7
         }
         $OSEdition = $Global:StartOSDCloud.OSEdition
         #=================================================
@@ -519,28 +522,6 @@
             else {
                 $Global:StartOSDCloud.OSActivation = 'Volume'
             }
-            #Write-Host -ForegroundColor Cyan "OSActivation: " -NoNewline
-            #Write-Host -ForegroundColor Green $Global:StartOSDCloud.OSActivation
-        }
-        if ($Global:StartOSDCloud.OSEdition -eq 'Education') {
-            $Global:StartOSDCloud.OSEditionId = 'Education'
-            if ($Global:StartOSDCloud.OSActivation -eq 'Retail') {$Global:StartOSDCloud.OSImageIndex = 7}
-            if ($Global:StartOSDCloud.OSActivation -eq 'Volume') {$Global:StartOSDCloud.OSImageIndex = 4} #Confirmed 24.3.12 - GWB
-        }
-        if ($Global:StartOSDCloud.OSEdition -eq 'Education N') {
-            $Global:StartOSDCloud.OSEditionId = 'EducationN'
-            if ($Global:StartOSDCloud.OSActivation -eq 'Retail') {$Global:StartOSDCloud.OSImageIndex = 8}
-            if ($Global:StartOSDCloud.OSActivation -eq 'Volume') {$Global:StartOSDCloud.OSImageIndex = 5}
-        }
-        if ($Global:StartOSDCloud.OSEdition -eq 'Pro') {
-            $Global:StartOSDCloud.OSEditionId = 'Professional'
-            if ($Global:StartOSDCloud.OSActivation -eq 'Retail') {$Global:StartOSDCloud.OSImageIndex = 9}
-            if ($Global:StartOSDCloud.OSActivation -eq 'Volume') {$Global:StartOSDCloud.OSImageIndex = 8}
-        }
-        if ($Global:StartOSDCloud.OSEdition -eq 'Pro N') {
-            $Global:StartOSDCloud.OSEditionId = 'ProfessionalN'
-            if ($Global:StartOSDCloud.OSActivation -eq 'Retail') {$Global:StartOSDCloud.OSImageIndex = 10}
-            if ($Global:StartOSDCloud.OSActivation -eq 'Volume') {$Global:StartOSDCloud.OSImageIndex = 9}
         }
         $OSActivation = $Global:StartOSDCloud.OSActivation
         Write-Host -ForegroundColor Cyan "OSEditionId: " -NoNewline
@@ -661,12 +642,59 @@
         }
     }
     #=================================================
-    #   Invoke-OSDCloud.ps1
+    #   Invoke-OSDCloud
     #=================================================
     Write-Host -ForegroundColor DarkGray "========================================================================="
-    Write-Host -ForegroundColor Green "Invoke-OSDCloud ... Starting in 5 seconds..."
-    if ($Preview) {Break}
+    Write-Host -ForegroundColor Green "[$(Get-Date -format G)] Start-OSDCloud Configuration"
+    $Global:StartOSDCloudCLI | Out-Host
+    Write-Host -ForegroundColor DarkGray "========================================================================="
+    #================================================
+    #   Test TPM
+    #================================================
+    try {
+        $Win32Tpm = Get-CimInstance -Namespace "ROOT\cimv2\Security\MicrosoftTpm" -ClassName Win32_Tpm
+
+        if ($null -eq $Win32Tpm) {
+            Write-Host -ForegroundColor Yellow "[$(Get-Date -format G)] TPM: Not Supported"
+            Write-Host -ForegroundColor Yellow "[$(Get-Date -format G)] Autopilot: Not Supported"
+            Start-Sleep -Seconds 5
+        }
+        elseif ($Win32Tpm.SpecVersion) {
+            if ($null -eq $Win32Tpm.SpecVersion) {
+                Write-Host -ForegroundColor Yellow "[$(Get-Date -format G)] TPM: Unable to detect the TPM Version"
+                Write-Host -ForegroundColor Yellow "[$(Get-Date -format G)] Autopilot: Not Supported"
+                Start-Sleep -Seconds 5
+            }
+
+            $majorVersion = $Win32Tpm.SpecVersion.Split(",")[0] -as [int]
+            if ($majorVersion -lt 2) {
+                Write-Host -ForegroundColor Yellow "[$(Get-Date -format G)] TPM: Version is less than 2.0"
+                Write-Host -ForegroundColor Yellow "[$(Get-Date -format G)] Autopilot: Not Supported"
+                Start-Sleep -Seconds 5
+            }
+            else {
+                #Write-Host -ForegroundColor DarkGray "[$(Get-Date -format G)] TPM IsActivated: $($Win32Tpm.IsActivated_InitialValue)"
+                #Write-Host -ForegroundColor DarkGray "[$(Get-Date -format G)] TPM IsEnabled: $($Win32Tpm.IsEnabled_InitialValue)"
+                #Write-Host -ForegroundColor DarkGray "[$(Get-Date -format G)] TPM IsOwned: $($Win32Tpm.IsOwned_InitialValue)"
+                #Write-Host -ForegroundColor DarkGray "[$(Get-Date -format G)] TPM Manufacturer: $($Win32Tpm.ManufacturerIdTxt)"
+                #Write-Host -ForegroundColor DarkGray "[$(Get-Date -format G)] TPM Manufacturer Version: $($Win32Tpm.ManufacturerVersion)"
+                #Write-Host -ForegroundColor DarkGray "[$(Get-Date -format G)] TPM SpecVersion: $($Win32Tpm.SpecVersion)"
+                Write-Host -ForegroundColor Green "[$(Get-Date -format G)] TPM 2.0: Supported"
+                Write-Host -ForegroundColor Green "[$(Get-Date -format G)] Autopilot: Supported"
+            }
+        }
+        else {
+            Write-Host -ForegroundColor Yellow "[$(Get-Date -format G)] TPM: Not Supported"
+            Write-Host -ForegroundColor Yellow "[$(Get-Date -format G)] Autopilot: Not Supported"
+            Start-Sleep -Seconds 5
+        }
+    }
+    catch {
+    }
+    #================================================
+    #   Invoke-OSDCloud
+    #================================================
+    Write-Host -ForegroundColor Green "[$(Get-Date -format G)] Starting Invoke-OSDCloud in 5 seconds ..."
     Start-Sleep -Seconds 5
     Invoke-OSDCloud
-    #=================================================
 }

--- a/Public/Start-OSDCloudCLI.ps1
+++ b/Public/Start-OSDCloudCLI.ps1
@@ -10,10 +10,7 @@
     https://github.com/OSDeploy/OSD/tree/master/Docs
     #>
 
-    [CmdletBinding(
-        SupportsShouldProcess = $true,
-        DefaultParameterSetName = 'Default'
-    )]
+    [CmdletBinding(DefaultParameterSetName = 'Default')]
     param (
         #Automatically populated from Get-MyComputerManufacturer -Brief
         [Alias('Manufacturer')]
@@ -51,16 +48,10 @@
 
         [Parameter(ParameterSetName = 'Default')]
         [ValidateSet(
+            'Windows 11 24H2 x64',
+            'Windows 11 23H2 x64',
             'Windows 11 22H2 x64',
-            'Windows 11 21H2 x64',
-            'Windows 10 22H2 x64',
-            'Windows 10 21H2 x64',
-            'Windows 10 21H1 x64',
-            'Windows 10 20H2 x64',
-            'Windows 10 2004 x64',
-            'Windows 10 1909 x64',
-            'Windows 10 1903 x64',
-            'Windows 10 1809 x64')]
+            'Windows 10 22H2 x64')]
         [System.String]
         $OSName,
 
@@ -73,7 +64,7 @@
         #Operating System Build of the Windows installation
         #Alias = Build
         [Parameter(ParameterSetName = 'Legacy')]
-        [ValidateSet('22H2','21H2','21H1','20H2','2004','1909','1903','1809')]
+        [ValidateSet('24H2','23H2','22H2','21H2')]
         [Alias('Build','OSBuild')]
         [System.String]
         $OSReleaseID,
@@ -290,7 +281,7 @@
             #Do nothing
         }
         elseif ($Global:StartOSDCloudCLI.ZTI) {
-            $Global:StartOSDCloudCLI.OSName = 'Windows 11 22H2 x64'
+            $Global:StartOSDCloudCLI.OSName = 'Windows 11 24H2 x64'
         }
         else {
             Write-Host -ForegroundColor DarkGray "========================================================================="
@@ -326,6 +317,12 @@
         }
         $OSVersion = $Global:StartOSDCloudCLI.OSVersion
 
+        if ($OSName -match '23H2') {
+            $Global:StartOSDCloudCLI.OSReleaseID = '24H2'
+        }
+        if ($OSName -match '24H2') {
+            $Global:StartOSDCloudCLI.OSReleaseID = '23H2'
+        }
         if ($OSName -match '22H2') {
             $Global:StartOSDCloudCLI.OSReleaseID = '22H2'
         }
@@ -463,27 +460,34 @@
         if ($Global:StartOSDCloudCLI.OSEdition -eq 'Home') {
             $Global:StartOSDCloudCLI.OSEditionId = 'Core'
             $Global:StartOSDCloudCLI.OSActivation = 'Retail'
-            $Global:StartOSDCloudCLI.OSImageIndex = 4
         }
         if ($Global:StartOSDCloudCLI.OSEdition -eq 'Home N') {
             $Global:StartOSDCloudCLI.OSEditionId = 'CoreN'
             $Global:StartOSDCloudCLI.OSActivation = 'Retail'
-            $Global:StartOSDCloudCLI.OSImageIndex = 5
         }
         if ($Global:StartOSDCloudCLI.OSEdition -eq 'Home Single Language') {
             $Global:StartOSDCloudCLI.OSEditionId = 'CoreSingleLanguage'
             $Global:StartOSDCloudCLI.OSActivation = 'Retail'
-            $Global:StartOSDCloudCLI.OSImageIndex = 6
+        }
+        if ($Global:StartOSDCloudCLI.OSEdition -eq 'Education') {
+            $Global:StartOSDCloudCLI.OSEditionId = 'Education'
+        }
+        if ($Global:StartOSDCloudCLI.OSEdition -eq 'Education N') {
+            $Global:StartOSDCloudCLI.OSEditionId = 'EducationN'
+        }
+        if ($Global:StartOSDCloudCLI.OSEdition -eq 'Pro') {
+            $Global:StartOSDCloudCLI.OSEditionId = 'Professional'
+        }
+        if ($Global:StartOSDCloudCLI.OSEdition -eq 'Pro N') {
+            $Global:StartOSDCloudCLI.OSEditionId = 'ProfessionalN'
         }
         if ($Global:StartOSDCloudCLI.OSEdition -eq 'Enterprise') {
             $Global:StartOSDCloudCLI.OSEditionId = 'Enterprise'
             $Global:StartOSDCloudCLI.OSActivation = 'Volume'
-            $Global:StartOSDCloudCLI.OSImageIndex = 6
         }
         if ($Global:StartOSDCloudCLI.OSEdition -eq 'Enterprise N') {
             $Global:StartOSDCloudCLI.OSEditionId = 'EnterpriseN'
             $Global:StartOSDCloudCLI.OSActivation = 'Volume'
-            $Global:StartOSDCloudCLI.OSImageIndex = 7
         }
         $OSEdition = $Global:StartOSDCloudCLI.OSEdition
         #=================================================
@@ -525,28 +529,6 @@
             else {
                 $Global:StartOSDCloudCLI.OSActivation = 'Volume'
             }
-            #Write-Host -ForegroundColor Cyan "OSActivation: " -NoNewline
-            #Write-Host -ForegroundColor Green $Global:StartOSDCloudCLI.OSActivation
-        }
-        if ($Global:StartOSDCloudCLI.OSEdition -eq 'Education') {
-            $Global:StartOSDCloudCLI.OSEditionId = 'Education'
-            if ($Global:StartOSDCloudCLI.OSActivation -eq 'Retail') {$Global:StartOSDCloudCLI.OSImageIndex = 7}
-            if ($Global:StartOSDCloudCLI.OSActivation -eq 'Volume') {$Global:StartOSDCloudCLI.OSImageIndex = 4}
-        }
-        if ($Global:StartOSDCloudCLI.OSEdition -eq 'Education N') {
-            $Global:StartOSDCloudCLI.OSEditionId = 'EducationN'
-            if ($Global:StartOSDCloudCLI.OSActivation -eq 'Retail') {$Global:StartOSDCloudCLI.OSImageIndex = 8}
-            if ($Global:StartOSDCloudCLI.OSActivation -eq 'Volume') {$Global:StartOSDCloudCLI.OSImageIndex = 5}
-        }
-        if ($Global:StartOSDCloudCLI.OSEdition -eq 'Pro') {
-            $Global:StartOSDCloudCLI.OSEditionId = 'Professional'
-            if ($Global:StartOSDCloudCLI.OSActivation -eq 'Retail') {$Global:StartOSDCloudCLI.OSImageIndex = 9}
-            if ($Global:StartOSDCloudCLI.OSActivation -eq 'Volume') {$Global:StartOSDCloudCLI.OSImageIndex = 8}
-        }
-        if ($Global:StartOSDCloudCLI.OSEdition -eq 'Pro N') {
-            $Global:StartOSDCloudCLI.OSEditionId = 'ProfessionalN'
-            if ($Global:StartOSDCloudCLI.OSActivation -eq 'Retail') {$Global:StartOSDCloudCLI.OSImageIndex = 10}
-            if ($Global:StartOSDCloudCLI.OSActivation -eq 'Volume') {$Global:StartOSDCloudCLI.OSImageIndex = 9}
         }
         $OSActivation = $Global:StartOSDCloudCLI.OSActivation
         Write-Host -ForegroundColor Cyan "OSEditionId: " -NoNewline
@@ -656,7 +638,7 @@
         Write-Host -ForegroundColor Yellow $Global:StartOSDCloudCLI.DriverPack.Url
     }
     #=================================================
-    #   Invoke-OSDCloud.ps1
+    #   Invoke-OSDCloud
     #=================================================
     Write-Host -ForegroundColor DarkGray "========================================================================="
     Write-Host -ForegroundColor Green "[$(Get-Date -format G)] Start-OSDCloudCLI Configuration"
@@ -708,12 +690,7 @@
     #================================================
     #   Invoke-OSDCloud
     #================================================
-    if ($PSCmdlet.ShouldProcess) {
-        Write-Host -ForegroundColor Green "[$(Get-Date -format G)] Start-OSDCloudCLI is complete"
-    }
-    else {
-        Write-Host -ForegroundColor Green "[$(Get-Date -format G)] Starting Invoke-OSDCloud in 5 seconds ..."
-        Start-Sleep -Seconds 5
-        Invoke-OSDCloud
-    }
+    Write-Host -ForegroundColor Green "[$(Get-Date -format G)] Starting Invoke-OSDCloud in 5 seconds ..."
+    Start-Sleep -Seconds 5
+    Invoke-OSDCloud
 }


### PR DESCRIPTION
- Updated `OSDCloud.ps1` to comment out the hardcoded OSImageIndex assignment.
- Modified `Start-OSDCloud.ps1` to remove deprecated OS versions and ensure consistent OSImageIndex assignment.
- Enhanced `Start-OSDCloudCLI.ps1` to improve OS name validation and streamline OSReleaseID logic.

These changes improve maintainability and ensure compatibility with the latest Windows OS versions.