### PR TITLE
Update Test-DISMFromOSDCloudUSB.ps1

### DIFF
--- a/Public/OSDCloudTS/Test-DISMFromOSDCloudUSB.ps1
+++ b/Public/OSDCloudTS/Test-DISMFromOSDCloudUSB.ps1
@@ -26,6 +26,8 @@
             $PackageID = $DriverPack.PackageID
         }
         $ComputerManufacturer = (Get-MyComputerManufacturer -Brief)
+        # Remove trailing dots and extra spaces (e.g. ASUSTeK Computer INC.)
+        $ComputerManufacturer = $ComputerManufacturer.Trim().TrimEnd('.')
         if ($ComputerManufacturer -match "Samsung"){$ComputerManufacturer = "Samsung"}
         $DriverPathProduct = "$($OSDCloudDriveLetter):\OSDCloud\DriverPacks\DISM\$ComputerManufacturer\$ComputerProduct"
         $DriverPathModel = "$($OSDCloudDriveLetter):\OSDCloud\DriverPacks\DISM\$ComputerManufacturer\$ComputerModel"
@@ -46,3 +48,4 @@
         return $false
     }
 }
+


### PR DESCRIPTION
Some manufacturers return their name with a trailing dot(.). For example: ASUSTeK Computer INC.

NTFS does not allow folder paths with a trailing dot (or whitespace)

Therefore, we should sanitize the manufacturer by removing these trailing characters before we build the paths.

This allows DISM to import an expanded driver back from a   manufacturer  not included with OSD cloud; and where drivers are not picked up from Windows update for some reason.