### PR TITLE
Add Test-WindowsUpdateEnvironment for windows update readiness checks

### DIFF
--- a/Public/OSDCloudTS/Start-WindowsUpdate.ps1
+++ b/Public/OSDCloudTS/Start-WindowsUpdate.ps1
@@ -1,4 +1,7 @@
 Function Start-WindowsUpdate{
+    if (-not (Test-WindowsUpdateEnvironment)) {
+        return
+    }
     <# Control Windows Update via PowerShell
     Installing Updates using this Method does NOT notify the user, and does NOT let the user know that updates need to be applied at the next reboot.  It's 100% hidden.
     HResult Lookup: https://docs.microsoft.com/en-us/windows/win32/wua_sdk/wua-success-and-error-codes-

--- a/Public/OSDCloudTS/Start-WindowsUpdateDrivers.ps1
+++ b/Public/OSDCloudTS/Start-WindowsUpdateDrivers.ps1
@@ -21,6 +21,9 @@ Function Get-WindowsUpdateDriver{
     }
 }
 Function Start-WindowsUpdateDriver{
+    if (-not (Test-WindowsUpdateEnvironment)) {
+        return
+    }
     <# Control Windows Update via PowerShell
     Installing Updates using this Method does NOT notify the user, and does NOT let the user know that updates need to be applied at the next reboot.  It's 100% hidden.
     HResult Lookup: https://docs.microsoft.com/en-us/windows/win32/wua_sdk/wua-success-and-error-codes-

--- a/Public/OSDCloudTS/Test-WindowsUpdateEnvironment.ps1
+++ b/Public/OSDCloudTS/Test-WindowsUpdateEnvironment.ps1
@@ -1,0 +1,49 @@
+function Test-WindowsUpdateEnvironment {
+    [CmdletBinding()]
+    param (
+        [int]$TimeoutSeconds = 30
+    )
+
+    # Check if network is available (max $TimeoutSeconds)
+    $networkReady = $false
+    for ($i = 0; $i -lt $TimeoutSeconds; $i++) {
+        if (Test-WebConnection -Uri 'www.microsoft.com') {
+            $networkReady = $true
+            break
+        }
+        Start-Sleep -Seconds 1
+    }
+    if (-not $networkReady) {
+        Write-Warning "Network is not available after waiting. Skipping Windows Update."
+        return $false
+    }
+
+    # Ensure Windows Update service is running (max $TimeoutSeconds)
+    # This is important to avoid COMException 0x80240438 when calling Microsoft.Update.Session
+    $serviceReady = $false
+    for ($i = 0; $i -lt $TimeoutSeconds; $i++) {
+        $service = Get-Service -Name wuauserv -ErrorAction SilentlyContinue
+        if ($service) {
+            if ($service.Status -eq 'Running') {
+                $serviceReady = $true
+                break
+            }
+            elseif ($service.Status -eq 'Stopped') {
+                try {
+                    Start-Service -Name wuauserv -ErrorAction Stop
+                    Write-Output "Windows Update service was stopped. Attempting to start it..."
+                } catch {
+                    Write-Warning "Failed to start Windows Update service: $($_.Exception.Message)"
+                }
+            }
+        }
+        Start-Sleep -Seconds 1
+    }
+
+    if (-not $serviceReady) {
+        Write-Warning "Windows Update service is not running. Skipping Windows Update."
+        return $false
+    }
+
+    return $true
+}

--- a/Public/OSDCloudTS/Update-DefenderStack.ps1
+++ b/Public/OSDCloudTS/Update-DefenderStack.ps1
@@ -1,7 +1,8 @@
 function Update-DefenderStack {
     [CmdletBinding()]
     param ()
-    if (Test-WebConnection -Uri "google.com") {
+#    if (Test-WebConnection -Uri "google.com") {
+    if (Test-WindowsUpdateEnvironment) {
         # Source Addresses - Defender for Windows 10, 8.1 ################################
         $sourceAVx64 = "http://go.microsoft.com/fwlink/?LinkID=121721&arch=x64"
         $sourcePlatformx64 = "https://go.microsoft.com/fwlink/?LinkID=870379&clcid=0x409&arch=x64"


### PR DESCRIPTION
### Summary (9/14/2025 Edited)

This pull request introduces a new function `Test-WindowsUpdateEnvironment` to perform pre-checks before executing Windows Update operations. It ensures:

- Network connectivity is available (`Test-WebConnection`)
- Windows Update service (`wuauserv`) is running, and starts it if necessary

These checks are critical to avoid COMException `0x80240438`, which occurs when `Microsoft.Update.Session` is called while the update service is not ready.

### Background

While testing the SetupComplete options in `Start-OSDCloudGUI`, specifically:

- Windows Update (No Drivers)
- Windows Update (Only Drivers)
- Windows Defeder Update

...the update process failed **when using Wi-Fi immediately after connection**. The first observed error was:

The network is not present or not started. (Exception from HRESULT: 0x800704C6)

Subsequent errors included failure to create the COM object `Microsoft.Update.Session`, and cases where the Windows Update service (`wuauserv`) was not in a running state. These issues were confirmed by reviewing `C:\OSDCloud\Logs\SetupComplete.log`.

Interestingly, the same update process worked fine when using a wired LAN connection, suggesting that the issue is related to timing and service readiness following Wi-Fi initialization.

To address this, the `Test-WindowsUpdateEnvironment` function was implemented and integrated into both `Start-WindowsUpdate` and `Start-WindowsUpdateDriver`. After applying this change, the update functionality worked as expected, even in Wi-Fi scenarios.

### Changes

- Added `Public/OSDCloudTS/Test-WindowsUpdateEnvironment.ps1`
- Modified `Start-WindowsUpdate.ps1` to call `Test-WindowsUpdateEnvironment` before update logic
- Modified `Start-WindowsUpdateDriver.ps1` similarly
- Modified `Update-DefenderStack.ps1` similarly

These changes were included via a rebase to incorporate additional atomic updates, and pushed using `--force-with-lease`.

### Impact

This change is backward-compatible and improves the robustness of update-related functions. It does not alter the core logic of update installation, only adds a pre-check layer to ensure readiness.

---

Let me know if any adjustments are needed. Thank you for maintaining this great project!
