### PR TITLE
Update version numbers and package URLs in OSDCloud functions scripts

### DIFF
--- a/cloud/modules/_anywhere.psm1
+++ b/cloud/modules/_anywhere.psm1
@@ -5,6 +5,7 @@
     OSDCloud Cloud Module for functions.osdcloud.com
 .NOTES
     This module can be loaded in all Windows phases
+    Version 25.9.10.1
 .LINK
     https://raw.githubusercontent.com/OSDeploy/OSD/master/cloud/modules/_anywhere.psm1
 .EXAMPLE
@@ -218,7 +219,8 @@ function osdcloud-InstallPackageManagement {
         $InstalledModule = Import-Module PackageManagement -PassThru -ErrorAction Ignore
         if (-not $InstalledModule) {
             Write-Host -ForegroundColor Yellow "[-] Install PackageManagement 1.4.8.1"
-            $PackageManagementURL = "https://psg-prod-eastus.azureedge.net/packages/packagemanagement.1.4.8.1.nupkg"
+            #$PackageManagementURL = "https://psg-prod-eastus.azureedge.net/packages/packagemanagement.1.4.8.1.nupkg"
+            $PackageManagementURL = 'https://www.powershellgallery.com/api/v2/package/PackageManagement/1.4.8.1/#manualdownload'
             Invoke-WebRequest -UseBasicParsing -Uri $PackageManagementURL -OutFile "$env:TEMP\packagemanagement.1.4.8.1.zip"
             $null = New-Item -Path "$env:TEMP\1.4.8.1" -ItemType Directory -Force
             Expand-Archive -Path "$env:TEMP\packagemanagement.1.4.8.1.zip" -DestinationPath "$env:TEMP\1.4.8.1"

--- a/cloud/modules/eq-winpe.psm1
+++ b/cloud/modules/eq-winpe.psm1
@@ -4,7 +4,7 @@
 .DESCRIPTION
     OSDCloud Cloud Module for functions.osdcloud.com
 .NOTES
-    Version 23.6.4.1
+    Version 25.9.10.1
 .LINK
     https://raw.githubusercontent.com/OSDeploy/OSD/master/cloud/modules/eq-winpe.psm1
 .EXAMPLE
@@ -39,7 +39,8 @@ function osdcloud-WinpeInstallPowerShellGet {
     $InstalledModule = Import-Module PowerShellGet -PassThru -ErrorAction Ignore
     if (-not (Get-Module -Name PowerShellGet -ListAvailable | Where-Object {$_.Version -ge '2.2.5'})) {
         Write-Host -ForegroundColor Yellow "[-] Install PowerShellGet 2.2.5"
-        $PowerShellGetURL = "https://psg-prod-eastus.azureedge.net/packages/powershellget.2.2.5.nupkg"
+        #$PowerShellGetURL = "https://psg-prod-eastus.azureedge.net/packages/powershellget.2.2.5.nupkg"
+        $PowerShellGetURL = 'https://www.powershellgallery.com/api/v2/package/PowerShellGet/2.2.5/#manualdownload'
         Invoke-WebRequest -UseBasicParsing -Uri $PowerShellGetURL -OutFile "$env:TEMP\powershellget.2.2.5.zip"
         $null = New-Item -Path "$env:TEMP\2.2.5" -ItemType Directory -Force
         Expand-Archive -Path "$env:TEMP\powershellget.2.2.5.zip" -DestinationPath "$env:TEMP\2.2.5"


### PR DESCRIPTION
- Changed PackageManagement and PowerShellGet download URLs to use PowerShell Gallery for better reliability

These changes ensure that the modules reference the latest versions and improve the download process.

PackageManagement will use URL (Same from OSD.Workspace): 'https://www.powershellgallery.com/api/v2/package/PackageManagement/1.4.8.1/#manualdownload'

PowerShellGet will use URL: 'https://www.powershellgallery.com/api/v2/package/PowerShellGet/2.2.5/#manualdownload'

You can test using 'sandbox.michaeltheadmin.com'