### PR TITLE
Fix FAT32 Cache Issues

### DIFF
--- a/Public/OSDCloud.ps1
+++ b/Public/OSDCloud.ps1
@@ -981,7 +981,7 @@
                     #=================================================
                     #	Cache to USB
                     #=================================================
-                    $OSDCloudUSB = Get-USBVolume | Where-Object {($_.FileSystemLabel -match 'OSDCloud') -or ($_.FileSystemLabel -match 'BHIMAGE')} | Where-Object {$_.SizeGB -ge 8} | Where-Object {$_.SizeRemainingGB -ge 5} | Select-Object -First 1
+                    $OSDCloudUSB = Get-USBVolume | Where-Object { $_.FileSystem -eq 'NTFS' } | Where-Object { $_.FileSystemLabel -match 'OSDCloud|BHIMAGE|USB-Data' } | Where-Object { $_.SizeGB -ge 8 } | Where-Object { $_.SizeRemainingGB -ge 5} | Select-Object -First 1
                     
                     if ($OSDCloudUSB -and $Global:OSDCloud.OSVersion -and $Global:OSDCloud.OSReleaseID) {
                         $OSDownloadChildPath = "$($OSDCloudUSB.DriveLetter):\OSDCloud\OS\$($Global:OSDCloud.OSVersion) $($Global:OSDCloud.OSReleaseID)"


### PR DESCRIPTION
- Modified the logic to select USB volumes by checking for NTFS file system.
- Expanded the file system label matching to include 'USB-Data' along with 'OSDCloud' and 'BHIMAGE'.
- Ensured that the selected USB volume meets size requirements for better compatibility.

This change enhances the flexibility of USB volume detection for OSDCloud operations.