### PR TITLE
Fix: Add Error handling for Invoke-WebRequest Header check

### DIFF
--- a/Public/Functions/Other/Save-WebFile.ps1
+++ b/Public/Functions/Other/Save-WebFile.ps1
@@ -117,7 +117,13 @@ function Save-WebFile {
             Write-Verbose "Destination: $DestinationFullName"
 
             Write-Verbose 'Requesing HTTP HEAD to get Content-Length and Accept-Ranges header'
-            $remote = Invoke-WebRequest -UseBasicParsing -Method Head -Uri $SourceUrl
+            try {
+                $remote = Invoke-WebRequest -UseBasicParsing -Method Head -Uri $SourceUrl
+            }
+            catch {
+                Write-Warning "$_" # Error Example: Response status code does not indicate success: 404 (Not Found).
+                Return $null
+            }
             $remoteLength = [Int64]($remote.Headers.'Content-Length' | Select-Object -First 1)
             $remoteAcceptsRanges = ($remote.Headers.'Accept-Ranges' | Select-Object -First 1) -eq 'bytes'
 


### PR DESCRIPTION

# Pull Request: Fix: Add error handling for Invoke-WebRequest HEAD check

## Change Summary
Added error handling around the HTTP `HEAD` request in `Save-WebFile.ps1` to prevent execution when the source URL returns an error (e.g., 404 Not Found).

## Code Added
```powershell
-$remote = Invoke-WebRequest -UseBasicParsing -Method Head -Uri $SourceUrl
+try {
+    $remote = Invoke-WebRequest -UseBasicParsing -Method Head -Uri $SourceUrl
+}
+catch {
+    Write-Warning "$_" # Error Example: Response status code does not indicate success: 404 (Not Found).
+    Return $null
+}
```

---

## Impact
- Only affects `Save-WebFile.ps1`.
- No other logic modified.
- Prevents downloading error HTML when the URL is invalid.

## Test Command
```powershell
Save-WebFile -SourceUrl "https://download.lenovo.com/pccbbs/mobiles/tp_x9-15_gen1_mt21q6-21q7_w11_24h2_202511notFound.exe" `
-DestinationName "notFound.exe" `
-DestinationDirectory C:\Temp\ `
-Verbose -Overwrite
```
