### PR TITLE
Add offline catalog support and preserve enterprise customizations during StartNet

### DIFF
--- a/Public/OSDCloudDriverPack/OSDCloud.DriverPack.ps1
+++ b/Public/OSDCloudDriverPack/OSDCloud.DriverPack.ps1
@@ -67,7 +67,17 @@ function Get-OSDCloudDriverPacks {
     #>
     [CmdletBinding()]
     param ()
-    $Results = Import-Clixml -Path "$(Get-OSDModulePath)\cache\driverpack-catalogs\build-driverpacks.xml"
+    $DriverCatalogXML = Get-PSDrive -PSProvider FileSystem | Where-Object {$_.Name -ne 'C'} | ForEach-Object {
+        Get-ChildItem "$($_.Root)OSDCloud\Catalogs" -Include "build-driverpacks.xml" -File -Force -Recurse -ErrorAction Ignore
+    }
+    if ($DriverCatalogXML) {
+        foreach ($Item in $DriverCatalogXML) {
+            Write-Host -ForegroundColor Gray "The default catalog is bypassed; referencing the $($Item.FullName) instead."
+            $Results = Import-Clixml -Path $Item.FullName
+        }
+    } else {
+        $Results = Import-Clixml -Path "$(Get-OSDModulePath)\cache\driverpack-catalogs\build-driverpacks.xml"
+    }
     $Results
 }
 function Save-OSDCloudDriverPack {

--- a/Public/OSDCloudTS/Get-OSDCloudOperatingSystems.ps1
+++ b/Public/OSDCloudTS/Get-OSDCloudOperatingSystems.ps1
@@ -16,12 +16,18 @@ function Get-OSDCloudOperatingSystems {
         [System.String]
         $OSArch = 'x64'
     )
-    $FullResults = Get-Content -Path "$(Get-OSDModulePath)\cache\archive-cloudoperatingsystems\CloudOperatingSystems.json" | ConvertFrom-Json
-    if ($OSArch -eq 'x64'){
-        $Results = $FullResults | Where-Object {$_.Architecture -eq "x64"}
+    $OfflineCatalog = Get-PSDrive -PSProvider FileSystem | Where-Object {$_.Name -ne 'C'} | ForEach-Object {
+        Get-ChildItem "$($_.Root)OSDCloud\Catalogs" -Include "CloudOperatingSystems.json" -File -Force -Recurse -ErrorAction Ignore
     }
-    elseif ($OSArch -eq "arm64"){
-        $Results = Get-Content -Path "$(Get-OSDModulePath)\cache\archive-cloudoperatingsystems\CloudOperatingSystemsARM64.json" | ConvertFrom-Json
+    if ($OfflineCatalog) {
+        foreach ($Item in $OfflineCatalog) {
+            Write-Host -ForegroundColor Gray "The default catalog is bypassed; referencing the $($Item.FullName) instead."
+            $FullResults = Get-Content -Path "$($Item.FullName)" | ConvertFrom-Json -ErrorAction "Stop"
+        }
+        $Results = $FullResults | Where-Object {$_.Architecture -eq $OSArch}
+    } else {
+        $FullResults = Get-Content -Path "$(Get-OSDModulePath)\cache\archive-cloudoperatingsystems\CloudOperatingSystems.json" | ConvertFrom-Json
+        $Results = $FullResults | Where-Object {$_.Architecture -eq $OSArch}
     }
     $Results
 }

--- a/Public/OSDCloudTS/Initialize-OSDCloudStartnet.ps1
+++ b/Public/OSDCloudTS/Initialize-OSDCloudStartnet.ps1
@@ -141,7 +141,28 @@ function Initialize-OSDCloudStartnet {
                 break
             }
         }
-
+        # PACHED START
+        if (Test-WebConnection -Uri "google.com") {
+            Write-Host -ForegroundColor Cyan '[i] Config Post StartNet Scripts'
+            $Global:ScriptStartNet2 = Get-PSDrive -PSProvider FileSystem | Where-Object { $_.Name -ne 'C' } | ForEach-Object {
+                Write-Host -ForegroundColor DarkGray "$($_.Root)OSDCloud\Config\Scripts\StartNet2\*.ps1"
+                Get-ChildItem "$($_.Root)OSDCloud\Config\Scripts\StartNet2\" -Include "*.ps1" -File -Recurse -Force -ErrorAction Ignore
+            }
+            if ($Global:ScriptStartNet2) {
+                $Global:ScriptStartNet2 = $Global:ScriptStartNet2 | Sort-Object -Property FullName
+                foreach ($Item in $Global:ScriptStartNet2) {
+                    Write-Host -ForegroundColor Gray "Execute $($Item.FullName)"
+                    & "$($Item.FullName)"
+                }
+                $TimeSpan = New-TimeSpan -Start $Global:StartnetStart -End (Get-Date)
+                Write-Host -ForegroundColor DarkGray "$($TimeSpan.ToString("mm':'ss")) Tried to execute Post StartNet Scripts" 
+            }
+        }
+        if ($Global:SkipOSDModuleInstall) {
+            Write-Host -ForegroundColor DarkGray "Skip Installing newer OSD PowerShell Module"
+            return
+        }
+        # PATCHED END
         # Check if the OSD Module in the PowerShell Gallery is newer than the installed version
         $TimeSpan = New-TimeSpan -Start $Global:StartnetStart -End (Get-Date)
         Write-Host -ForegroundColor DarkGray "$($TimeSpan.ToString("mm':'ss")) Updating OSD PowerShell Module"


### PR DESCRIPTION
## Summary
This PR introduces **opt‑in capabilities** that make OSDCloud more adaptable in enterprise deployment scenarios—without changing the module’s default behavior.  
It enables organizations to load **offline catalogs**, preserve **enterprise customizations** by controlling module self‑updates, and run **post‑StartNet scripts** when network connectivity is available.

These enhancements are intentionally scoped, self‑contained, and backward‑compatible.

---

## Why
Enterprise IT teams often maintain their own validated or version‑pinned catalogs and need predictable behavior during deployment.  
They may also embed custom StartNet logic or require early‑stage workflow extensions that should not be overwritten by automatic module updates.

This PR isolates a subset of improvements from a broader earlier proposal, keeping the scope narrowly focused on:
1. Offline catalog enablement  
2. Preservation of enterprise customizations  
3. Controlled post‑StartNet workflow extension  

All without altering the default OSDCloud experience.

---

## What’s Included (All Optional)

### 1. Offline Catalog Loading (Drivers / OS)
- Scans all non‑`C:` file system volumes for:
  - `OSDCloud\Catalogs\build-driverpacks.xml`
  - `OSDCloud\Catalogs\CloudOperatingSystems.json`
- If one or more catalogs are found, **the last detected catalog** is used.
- Allows enterprise environments to:
  - Supply validated or customized catalogs on removable or secondary media  
  - Keep catalog behavior deterministic and version‑controlled  

---

### 2. Preservation of Enterprise Customizations
- Adds logic to skip automatic OSD module installation/updates when:
  - `$Global:SkipOSDModuleInstall = $true` This can be set exiting hook: `OSDCloud\Config\Scripts\StartNet\*.ps1`
- Prevents:
  - Overwriting embedded catalogs  
  - Replacing enterprise customization logic  
  - Accidental version drift during controlled deployment workflows  

This maintains a clean separation between enterprise customizations and default module behavior.

---

### 3. Controlled Post‑StartNet Script Execution
- When network connectivity becomes available in WinPE, OSDCloud may call an optional enterprise‑provided script such as `DownloadValidatedCatalogs.ps1`.
- Scripts may be discovered under `OSDCloud\Config\Scripts\StartNet2\*.ps1`.
- Allows organizations to:
  - Refresh or validate offline catalogs  
  - Run compliance or environment checks 

Execution only occurs when both **network connectivity** and **enterprise script presence** are confirmed.

---

## Compatibility
- Fully backward‑compatible  
- All enhancements are opt‑in and do **not** alter default OSD behavior  
- Existing enterprise customizations remain untouched when skip‑update logic is enabled  
- Offline catalog handling is isolated from all other catalog‑related changes submitted previously  

---

## Testing
- Tested using Start-OSDCloudGUI 
- Verified offline catalog detection on:
  - USB removable media (FAT32/NTFS)
  - Catalog files on enterprise-managed cloud storage  
- Confirmed that $Global:SkipOSDModuleInstall = $true correctly prevents self‑update  
- Validated StartNet2 execution triggers only under correct network conditions  
- Confirmed no regressions in default online‑catalog behavior  
