### PR TITLE
Hyper-V VM: look for passthrough disks that are likely Offline USB (SSD/NVMe) drives

### DIFF
--- a/Public/Functions/Disk.ps1
+++ b/Public/Functions/Disk.ps1
@@ -585,8 +585,17 @@ function Get-USBDisk {
     param ()
     #=================================================
     #	Get-OSDDisk
+    #   Hyper-V VM: look for passthrough disks that are likely Offline USB (SSD/NVMe) drives
     #=================================================
-    $GetDisk = Get-OSDDisk -BusType USB
+    $isVM = Test-isVM
+
+    if ($isVM) {
+        $GetDisk = Get-OSDDisk -MediaType SSD
+    }
+    else {
+        $GetDisk = Get-OSDDisk -BusType USB
+    }
+    
     #=================================================
     #	Return
     #=================================================


### PR DESCRIPTION
- Add an if/else block to the `Get-USBDisk` function and use the `Test-IsVM` function to detect when we are working inside a VM
- If working inside a VM, use `Get-OSDDisk -MediaType SSD` to detect additional offline/passthrough host drives

**This patch has only been tested with Hyper-V. Please test with other hypervisors.
**This only works with SSD/NVMe USB enclosures. Standard USB flash drives are typically not able to be put offline in `diskmgmt.msc`

Closes #348 