### PR TITLE
Fix: derive OSVersion and OSBuild from OSName in Default parameter set

### DIFF
--- a/Public/Start-OSDCloud.ps1
+++ b/Public/Start-OSDCloud.ps1
@@ -435,6 +435,19 @@ function Start-OSDCloud {
         }
         $OSName = $Global:StartOSDCloud.OSName
         Write-Host -ForegroundColor DarkGray "[$(Get-Date -format G)] OSName is set to $($Global:StartOSDCloud.OSName)"
+        #=================================================
+        #	Derive OSVersion and OSBuild from OSName so that downstream
+        #	logic (notably OSDCloudUSB OS caching in OSDCloud.ps1) works
+        #	identically to the Legacy parameter set. Without this, users
+        #	starting with -OSName get $null for OSVersion/OSBuild, which
+        #	silently disables the automatic OS cache to USB.
+        #=================================================
+        if ($Global:StartOSDCloud.OSName -match '^(Windows \d+)\s+(\S+)\s+x64$') {
+            $Global:StartOSDCloud.OSVersion = $Matches[1]
+            $Global:StartOSDCloud.OSBuild   = $Matches[2]
+            Write-Host -ForegroundColor DarkGray "[$(Get-Date -format G)] OSVersion derived from OSName: $($Global:StartOSDCloud.OSVersion)"
+            Write-Host -ForegroundColor DarkGray "[$(Get-Date -format G)] OSBuild derived from OSName: $($Global:StartOSDCloud.OSBuild)"
+        }
     }
     elseif ($PSCmdlet.ParameterSetName -eq 'Legacy') {
         #=================================================


### PR DESCRIPTION
When Start-OSDCloud is invoked with -OSName (Default parameter set), OSVersion and OSBuild were left $null, which silently disabled the automatic OS cache to OSDCloudUSB in OSDCloud.ps1:986. DriverPacks were cached correctly, but the OS image was downloaded straight to C:\OSDCloud\OS and never persisted to the USB for future runs.

Parsing OSName (e.g. 'Windows 11 25H2 x64') into OSVersion and OSBuild after it is resolved makes the downstream global state identical to the Legacy parameter set, restoring the expected auto-caching behavior without touching any caching logic.